### PR TITLE
hotfix/wrong invoke constructor ptrconversion

### DIFF
--- a/src/kt_class.cpp
+++ b/src/kt_class.cpp
@@ -18,7 +18,7 @@ KtClass::~KtClass() {
 KtObject* KtClass::create_instance(jni::Env& env, const Variant** p_args, int p_arg_count, Object* p_owner) {
     jni::MethodId new_method { get_method_id(env, "new", "(JI)Lgodot/core/KtObject;") };
     // TODO: send args
-    jni::JObject j_kt_object { wrapped.call_object_method(env, new_method, {reinterpret_cast<long>(p_owner),
+    jni::JObject j_kt_object { wrapped.call_object_method(env, new_method, {static_cast<jint>(reinterpret_cast<uintptr_t>(p_owner)),
                                                                             static_cast<jint>(p_arg_count)}) };
     print_verbose(vformat("Instantiated an object of type %s", name));
     return new KtObject(j_kt_object, class_loader, name);

--- a/src/transfer_context.cpp
+++ b/src/transfer_context.cpp
@@ -144,7 +144,7 @@ jlong TransferContext::invoke_constructor(JNIEnv *p_raw_env, jobject p_instance,
     StringName class_name = env.from_jstring(jni::JString(p_class_name));
     Object* ptr = ClassDB::instance(class_name);
     ERR_FAIL_COND_V_MSG(!ptr, 0, vformat("Failed to instantiate class %s", class_name))
-    return reinterpret_cast<long>(ptr);
+    return reinterpret_cast<uintptr_t>(ptr);
 }
 
 void TransferContext::set_script(JNIEnv *p_raw_env, jobject p_instance, jlong p_raw_ptr, jstring p_class_name,


### PR DESCRIPTION
This fixes crash when trying to use the ptr created from invoke_constructor stored in JVM instance.