### PR TITLE
Add support for user type in signal arguments

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -33,9 +33,10 @@ class OtherScript : Node() {
 //		This needs the use of user defined constructors when crossing boundaries
 //		see: KtVariant::asObject() and Bootstrap::registerManagedEngineTypes methods.
 //
-//	fun hookTwoParam(str: String, inv: Invocation) {
-//		println("Hook was calles with parameters: $str, $inv")
-//	}
+    @RegisterFunction
+	fun hookTwoParamInvocation(str: String, inv: Invocation) {
+		println("Hook was called with parameters (invocation): $str, $inv")
+	}
 
 }
 
@@ -56,6 +57,9 @@ class Invocation : Spatial() {
 
     @RegisterSignal
     val signalTwoParam by signal<String, Invocation>("str", "inv")
+
+    @RegisterSignal
+    val signalTwoParamInvocation by signal<String, Invocation>("str", "inv")
 
     @RegisterFunction
     fun intValue(value: Int) = value
@@ -96,9 +100,11 @@ class Invocation : Spatial() {
 		signalNoParam.connect(invocation, invocation::hookNoParam)
 		signalOneParam.connect(invocation, invocation::hookOneParam)
 		signalTwoParam.connect(invocation, invocation::hookTwoParam)
+		signalTwoParamInvocation.connect(invocation, invocation::hookTwoParamInvocation)
 		signalNoParam.emit()
 		signalOneParam.emit(false)
 		signalTwoParam.emit("My Awesome param !", this)
+        signalTwoParamInvocation.emit("My Awesome param (invocation)!", this)
 	}
 
 	override fun _onInit() {

--- a/kt/godot-runtime/src/main/java/godot/wire/Wire.java
+++ b/kt/godot-runtime/src/main/java/godot/wire/Wire.java
@@ -7568,6 +7568,18 @@ public final class Wire {
      * @return The engineConstructorIndex.
      */
     int getEngineConstructorIndex();
+
+    /**
+     * <code>int32 user_constructor_index = 3;</code>
+     * @return The userConstructorIndex.
+     */
+    int getUserConstructorIndex();
+
+    /**
+     * <code>bool is_user_type = 4;</code>
+     * @return The isUserType.
+     */
+    boolean getIsUserType();
   }
   /**
    * Protobuf type {@code wire.Object}
@@ -7624,6 +7636,16 @@ public final class Wire {
               engineConstructorIndex_ = input.readInt32();
               break;
             }
+            case 24: {
+
+              userConstructorIndex_ = input.readInt32();
+              break;
+            }
+            case 32: {
+
+              isUserType_ = input.readBool();
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -7678,6 +7700,28 @@ public final class Wire {
       return engineConstructorIndex_;
     }
 
+    public static final int USER_CONSTRUCTOR_INDEX_FIELD_NUMBER = 3;
+    private int userConstructorIndex_;
+    /**
+     * <code>int32 user_constructor_index = 3;</code>
+     * @return The userConstructorIndex.
+     */
+    @java.lang.Override
+    public int getUserConstructorIndex() {
+      return userConstructorIndex_;
+    }
+
+    public static final int IS_USER_TYPE_FIELD_NUMBER = 4;
+    private boolean isUserType_;
+    /**
+     * <code>bool is_user_type = 4;</code>
+     * @return The isUserType.
+     */
+    @java.lang.Override
+    public boolean getIsUserType() {
+      return isUserType_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -7698,6 +7742,12 @@ public final class Wire {
       if (engineConstructorIndex_ != 0) {
         output.writeInt32(2, engineConstructorIndex_);
       }
+      if (userConstructorIndex_ != 0) {
+        output.writeInt32(3, userConstructorIndex_);
+      }
+      if (isUserType_ != false) {
+        output.writeBool(4, isUserType_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -7714,6 +7764,14 @@ public final class Wire {
       if (engineConstructorIndex_ != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(2, engineConstructorIndex_);
+      }
+      if (userConstructorIndex_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, userConstructorIndex_);
+      }
+      if (isUserType_ != false) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, isUserType_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -7734,6 +7792,10 @@ public final class Wire {
           != other.getPtr()) return false;
       if (getEngineConstructorIndex()
           != other.getEngineConstructorIndex()) return false;
+      if (getUserConstructorIndex()
+          != other.getUserConstructorIndex()) return false;
+      if (getIsUserType()
+          != other.getIsUserType()) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -7750,6 +7812,11 @@ public final class Wire {
           getPtr());
       hash = (37 * hash) + ENGINE_CONSTRUCTOR_INDEX_FIELD_NUMBER;
       hash = (53 * hash) + getEngineConstructorIndex();
+      hash = (37 * hash) + USER_CONSTRUCTOR_INDEX_FIELD_NUMBER;
+      hash = (53 * hash) + getUserConstructorIndex();
+      hash = (37 * hash) + IS_USER_TYPE_FIELD_NUMBER;
+      hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
+          getIsUserType());
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -7887,6 +7954,10 @@ public final class Wire {
 
         engineConstructorIndex_ = 0;
 
+        userConstructorIndex_ = 0;
+
+        isUserType_ = false;
+
         return this;
       }
 
@@ -7915,6 +7986,8 @@ public final class Wire {
         godot.wire.Wire.Object result = new godot.wire.Wire.Object(this);
         result.ptr_ = ptr_;
         result.engineConstructorIndex_ = engineConstructorIndex_;
+        result.userConstructorIndex_ = userConstructorIndex_;
+        result.isUserType_ = isUserType_;
         onBuilt();
         return result;
       }
@@ -7968,6 +8041,12 @@ public final class Wire {
         }
         if (other.getEngineConstructorIndex() != 0) {
           setEngineConstructorIndex(other.getEngineConstructorIndex());
+        }
+        if (other.getUserConstructorIndex() != 0) {
+          setUserConstructorIndex(other.getUserConstructorIndex());
+        }
+        if (other.getIsUserType() != false) {
+          setIsUserType(other.getIsUserType());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -8056,6 +8135,68 @@ public final class Wire {
       public Builder clearEngineConstructorIndex() {
         
         engineConstructorIndex_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int userConstructorIndex_ ;
+      /**
+       * <code>int32 user_constructor_index = 3;</code>
+       * @return The userConstructorIndex.
+       */
+      @java.lang.Override
+      public int getUserConstructorIndex() {
+        return userConstructorIndex_;
+      }
+      /**
+       * <code>int32 user_constructor_index = 3;</code>
+       * @param value The userConstructorIndex to set.
+       * @return This builder for chaining.
+       */
+      public Builder setUserConstructorIndex(int value) {
+        
+        userConstructorIndex_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 user_constructor_index = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearUserConstructorIndex() {
+        
+        userConstructorIndex_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private boolean isUserType_ ;
+      /**
+       * <code>bool is_user_type = 4;</code>
+       * @return The isUserType.
+       */
+      @java.lang.Override
+      public boolean getIsUserType() {
+        return isUserType_;
+      }
+      /**
+       * <code>bool is_user_type = 4;</code>
+       * @param value The isUserType to set.
+       * @return This builder for chaining.
+       */
+      public Builder setIsUserType(boolean value) {
+        
+        isUserType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>bool is_user_type = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearIsUserType() {
+        
+        isUserType_ = false;
         onChanged();
         return this;
       }
@@ -13145,25 +13286,26 @@ public final class Wire {
       "\001(\0132\r.wire.Vector3\022\030\n\001z\030\003 \001(\0132\r.wire.Vec" +
       "tor3\"F\n\tTransform\022\032\n\005basis\030\001 \001(\0132\013.wire." +
       "Basis\022\035\n\006origin\030\002 \001(\0132\r.wire.Vector3\"\016\n\014" +
-      "VariantArray\"7\n\006Object\022\013\n\003ptr\030\001 \001(\006\022 \n\030e" +
-      "ngine_constructor_index\030\002 \001(\005\"\263\004\n\005Value\022" +
-      "\023\n\tnil_value\030\001 \001(\005H\000\022\024\n\nbool_value\030\002 \001(\010" +
-      "H\000\022\024\n\nlong_value\030\003 \001(\003H\000\022\024\n\nreal_value\030\004" +
-      " \001(\001H\000\022\026\n\014string_value\030\005 \001(\tH\000\022&\n\rvector" +
-      "2_value\030\006 \001(\0132\r.wire.Vector2H\000\022\"\n\013rect2_" +
-      "value\030\007 \001(\0132\013.wire.Rect2H\000\022&\n\rvector3_va" +
-      "lue\030\010 \001(\0132\r.wire.Vector3H\000\022.\n\021transform2" +
-      "D_value\030\t \001(\0132\021.wire.Transform2DH\000\022\"\n\013pl" +
-      "ane_value\030\n \001(\0132\013.wire.PlaneH\000\022 \n\nquat_v" +
-      "alue\030\013 \001(\0132\n.wire.QuatH\000\022 \n\naabb_value\030\014" +
-      " \001(\0132\n.wire.AABBH\000\022\"\n\013basis_value\030\r \001(\0132" +
-      "\013.wire.BasisH\000\022*\n\017transform_value\030\016 \001(\0132" +
-      "\017.wire.TransformH\000\0221\n\023variant_array_valu" +
-      "e\030\017 \001(\0132\022.wire.VariantArrayH\000\022$\n\014object_" +
-      "value\030\020 \001(\0132\014.wire.ObjectH\000B\006\n\004type\"(\n\013R" +
-      "eturnValue\022\031\n\004data\030\001 \001(\0132\013.wire.Value\"%\n" +
-      "\010FuncArgs\022\031\n\004args\030\001 \003(\0132\013.wire.ValueB\014\n\n" +
-      "godot.wireb\006proto3"
+      "VariantArray\"m\n\006Object\022\013\n\003ptr\030\001 \001(\006\022 \n\030e" +
+      "ngine_constructor_index\030\002 \001(\005\022\036\n\026user_co" +
+      "nstructor_index\030\003 \001(\005\022\024\n\014is_user_type\030\004 " +
+      "\001(\010\"\263\004\n\005Value\022\023\n\tnil_value\030\001 \001(\005H\000\022\024\n\nbo" +
+      "ol_value\030\002 \001(\010H\000\022\024\n\nlong_value\030\003 \001(\003H\000\022\024" +
+      "\n\nreal_value\030\004 \001(\001H\000\022\026\n\014string_value\030\005 \001" +
+      "(\tH\000\022&\n\rvector2_value\030\006 \001(\0132\r.wire.Vecto" +
+      "r2H\000\022\"\n\013rect2_value\030\007 \001(\0132\013.wire.Rect2H\000" +
+      "\022&\n\rvector3_value\030\010 \001(\0132\r.wire.Vector3H\000" +
+      "\022.\n\021transform2D_value\030\t \001(\0132\021.wire.Trans" +
+      "form2DH\000\022\"\n\013plane_value\030\n \001(\0132\013.wire.Pla" +
+      "neH\000\022 \n\nquat_value\030\013 \001(\0132\n.wire.QuatH\000\022 " +
+      "\n\naabb_value\030\014 \001(\0132\n.wire.AABBH\000\022\"\n\013basi" +
+      "s_value\030\r \001(\0132\013.wire.BasisH\000\022*\n\017transfor" +
+      "m_value\030\016 \001(\0132\017.wire.TransformH\000\0221\n\023vari" +
+      "ant_array_value\030\017 \001(\0132\022.wire.VariantArra" +
+      "yH\000\022$\n\014object_value\030\020 \001(\0132\014.wire.ObjectH" +
+      "\000B\006\n\004type\"(\n\013ReturnValue\022\031\n\004data\030\001 \001(\0132\013" +
+      ".wire.Value\"%\n\010FuncArgs\022\031\n\004args\030\001 \003(\0132\013." +
+      "wire.ValueB\014\n\ngodot.wireb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -13234,7 +13376,7 @@ public final class Wire {
     internal_static_wire_Object_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_wire_Object_descriptor,
-        new java.lang.String[] { "Ptr", "EngineConstructorIndex", });
+        new java.lang.String[] { "Ptr", "EngineConstructorIndex", "UserConstructorIndex", "IsUserType", });
     internal_static_wire_Value_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_wire_Value_fieldAccessorTable = new

--- a/kt/godot-runtime/src/main/kotlin/godot/core/KtClass.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/KtClass.kt
@@ -5,7 +5,7 @@ import godot.util.VoidPtr
 class KtClass<T : KtObject>(
         val name: String,
         val superClass: String,
-        private val constructors: Map<Int, KtConstructor<T>>,
+        val constructors: Map<Int, KtConstructor<T>>,
         private val _properties: Map<String, KtProperty<T, *>>,
         private val _functions: Map<String, KtFunction<T, *>>,
         private val _signalInfos: Map<String, KtSignalInfo>

--- a/kt/godot-runtime/src/main/kotlin/godot/core/TypeManager.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/TypeManager.kt
@@ -1,19 +1,25 @@
 package godot.core
 
+import godot.util.VoidPtr
+
 object TypeManager {
-    private val userTypes = HashSet<String>()
+    val userTypeNames = LinkedHashSet<String>()
+    val userTypeConstructors = mutableListOf<(VoidPtr) -> KtObject>()
 
     val engineTypeNames = LinkedHashSet<String>()
-    val engineTypesConstructors = mutableListOf<() -> KtObject>()
+    val engineTypeConstructors = mutableListOf<() -> KtObject>()
 
-    fun registerUserType(className: String) = userTypes.add(className)
+    fun <T: KtObject> registerUserType(className: String, invocator: (rawPtr: VoidPtr) -> T) {
+        userTypeConstructors.add(invocator)
+        userTypeNames.add(className)
+    }
 
     fun <T: KtObject> registerEngineType(className: String, invocator: () -> T) {
-        engineTypesConstructors.add(invocator)
+        engineTypeConstructors.add(invocator)
         engineTypeNames.add(className)
     }
 
-    fun isUserType(className: String) = userTypes.contains(className)
+    fun isUserType(className: String) = userTypeNames.contains(className)
 
     fun isEngineType(className: String) = engineTypeNames.contains(className)
 }

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Variants.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Variants.kt
@@ -232,10 +232,15 @@ class KtVariant {
 
     inline fun <reified T : KtObject> asObject(): T {
         val objectValue = data.objectValue
+        if (objectValue.isUserType) {
+            val constructor = TypeManager.userTypeConstructors[objectValue.userConstructorIndex]
+            return constructor(objectValue.ptr) as T
+        }
+
         val constructorIndex = objectValue.engineConstructorIndex
         return KtObject.instantiateWith(
-                objectValue.ptr,
-                TypeManager.engineTypesConstructors[constructorIndex]
+            objectValue.ptr,
+            TypeManager.engineTypeConstructors[constructorIndex]
         ) as T
     }
 

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -80,6 +80,9 @@ class Bootstrap {
             registerManagedEngineTypes(
                     TypeManager.engineTypeNames.toTypedArray()
             )
+            registerManagedUserTypes(
+                    TypeManager.userTypeNames.toTypedArray()
+            )
         } else {
             System.err.println("Unable to find Entry class, no classes will be loaded")
         }
@@ -89,4 +92,5 @@ class Bootstrap {
     private external fun unloadClasses(classes: Array<KtClass<*>>)
 
     private external fun registerManagedEngineTypes(engineTypesNames: Array<String>)
+    private external fun registerManagedUserTypes(engineTypesNames: Array<String>)
 }

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
@@ -657,8 +657,9 @@ class ClassRegistry {
     fun <T : KtObject> registerClass(name: String, superClass: String, isTool: Boolean = false, cb: ClassBuilderDsl<T>.() -> Unit) {
         val builder = ClassBuilderDsl<T>(name, superClass)
         builder.cb()
-        TypeManager.registerUserType(name)
-        registerClass(builder.build())
+        val clazz = builder.build()
+        TypeManager.registerUserType(name) { voidPtr -> clazz.new(voidPtr, 0) }
+        registerClass(clazz)
     }
 
     private fun <T : KtObject> registerClass(cls: KtClass<T>) {

--- a/protos/wire.proto
+++ b/protos/wire.proto
@@ -59,6 +59,8 @@ message VariantArray {
 message Object {
   fixed64 ptr = 1;
   int32 engine_constructor_index = 2;
+  int32 user_constructor_index = 3;
+  bool is_user_type = 4;
 }
 
 message Value {

--- a/regen_protos.sh
+++ b/regen_protos.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-./libprotobuf/bin/protoc --java_out=kt/godot-runtime/src/main/java --cpp_out=src/wire/  protos/wire.proto
+./libprotobuf/bin/protoc --proto_path=protos/ --java_out=kt/godot-runtime/src/main/java --cpp_out=src/wire/ wire.proto

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -7,7 +7,8 @@ Bootstrap::Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader) : Java
 
 void
 Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
-                          RegisterManagedEngineTypes p_register_managed_engine_types_hook) {
+                          RegisterManagedEngineTypes p_register_managed_engine_types_hook,
+                          RegisterManagedUserTypes p_register_managed_user_types_hook) {
     jni::JNativeMethod load_class_hook_method {
             "loadClasses",
             "([Lgodot/core/KtClass;)V",
@@ -26,10 +27,17 @@ Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, 
             (void*) p_register_managed_engine_types_hook
     };
 
+    jni::JNativeMethod register_managed_user_types_method{
+            "registerManagedUserTypes",
+            "([Ljava/lang/String;)V",
+            (void*) p_register_managed_user_types_hook
+    };
+
     Vector<jni::JNativeMethod> methods;
     methods.push_back(load_class_hook_method);
     methods.push_back(unload_class_hook_method);
     methods.push_back(register_managed_engine_types_method);
+    methods.push_back(register_managed_user_types_method);
     get_class(p_env).register_natives(p_env, methods);
 }
 

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -8,12 +8,13 @@ public:
     typedef void (*LoadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*UnloadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*RegisterManagedEngineTypes)(JNIEnv* p_env, jobject p_this, jobjectArray classes_names);
+    typedef void (*RegisterManagedUserTypes)(JNIEnv* p_env, jobject p_this, jobjectArray classes_names);
 
     Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader);
     ~Bootstrap() = default;
 
     void register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
-                        RegisterManagedEngineTypes p_register_managed_engine_types_hook);
+                        RegisterManagedEngineTypes p_register_managed_engine_types_hook, RegisterManagedUserTypes p_reguster_managed_user_types_hook);
     void init(jni::Env& env, bool p_is_editor, const String& p_project_dir);
     void finish(jni::Env& p_env);
 };

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -79,7 +79,7 @@ void GDKotlin::init() {
     jni::MethodId ctor = bootstrap_cls.get_constructor_method_id(env, "()V");
     jni::JObject instance = bootstrap_cls.new_instance(env, ctor);
     bootstrap = new Bootstrap(instance, class_loader);
-    bootstrap->register_hooks(env, load_classes_hook, unload_classes_hook, KtVariant::register_engine_types);
+    bootstrap->register_hooks(env, load_classes_hook, unload_classes_hook, KtVariant::register_engine_types, KtVariant::register_user_types);
     bool is_editor = Engine::get_singleton()->is_editor_hint();
     String project_path = project_settings->globalize_path("res://");
     bootstrap->init(env, is_editor, project_path);

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -4,6 +4,7 @@
 #include "core/variant.h"
 #include "jni/wrapper.h"
 #include "java_instance_wrapper.h"
+#include "kt_property.h"
 
 class KtVariant {
 private:
@@ -13,12 +14,15 @@ public:
     KtVariant() = default;
     KtVariant(wire::Value value);
     KtVariant(const Variant& variant);
+    KtVariant(const Variant& variant, const KtPropertyInfo* argInfo);
     ~KtVariant() = default;
 
     static void initMethodArray();
     static Variant::Type fromWireTypeToVariantType(wire::Value::TypeCase typeCase);
     static void register_engine_types(JNIEnv* p_env, jobject p_this, jobjectArray p_engine_types_names);
+    static void register_user_types(JNIEnv* p_env, jobject p_this, jobjectArray p_user_type_names);
     static void clear_engine_types();
+    static void clear_user_types();
 
     const wire::Value& get_value() const;
     Variant to_godot_variant() const;

--- a/src/wire/wire.pb.cc
+++ b/src/wire/wire.pb.cc
@@ -401,6 +401,8 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_wire_2eproto::offsets[] PROTOB
   ~0u,  // no _weak_field_map_
   PROTOBUF_FIELD_OFFSET(::wire::Object, ptr_),
   PROTOBUF_FIELD_OFFSET(::wire::Object, engine_constructor_index_),
+  PROTOBUF_FIELD_OFFSET(::wire::Object, user_constructor_index_),
+  PROTOBUF_FIELD_OFFSET(::wire::Object, is_user_type_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::wire::Value, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -448,9 +450,9 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 61, -1, sizeof(::wire::Transform)},
   { 68, -1, sizeof(::wire::VariantArray)},
   { 73, -1, sizeof(::wire::Object)},
-  { 80, -1, sizeof(::wire::Value)},
-  { 102, -1, sizeof(::wire::ReturnValue)},
-  { 108, -1, sizeof(::wire::FuncArgs)},
+  { 82, -1, sizeof(::wire::Value)},
+  { 104, -1, sizeof(::wire::ReturnValue)},
+  { 110, -1, sizeof(::wire::FuncArgs)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -486,25 +488,26 @@ const char descriptor_table_protodef_wire_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
   "\001(\0132\r.wire.Vector3\022\030\n\001z\030\003 \001(\0132\r.wire.Vec"
   "tor3\"F\n\tTransform\022\032\n\005basis\030\001 \001(\0132\013.wire."
   "Basis\022\035\n\006origin\030\002 \001(\0132\r.wire.Vector3\"\016\n\014"
-  "VariantArray\"7\n\006Object\022\013\n\003ptr\030\001 \001(\006\022 \n\030e"
-  "ngine_constructor_index\030\002 \001(\005\"\263\004\n\005Value\022"
-  "\023\n\tnil_value\030\001 \001(\005H\000\022\024\n\nbool_value\030\002 \001(\010"
-  "H\000\022\024\n\nlong_value\030\003 \001(\003H\000\022\024\n\nreal_value\030\004"
-  " \001(\001H\000\022\026\n\014string_value\030\005 \001(\tH\000\022&\n\rvector"
-  "2_value\030\006 \001(\0132\r.wire.Vector2H\000\022\"\n\013rect2_"
-  "value\030\007 \001(\0132\013.wire.Rect2H\000\022&\n\rvector3_va"
-  "lue\030\010 \001(\0132\r.wire.Vector3H\000\022.\n\021transform2"
-  "D_value\030\t \001(\0132\021.wire.Transform2DH\000\022\"\n\013pl"
-  "ane_value\030\n \001(\0132\013.wire.PlaneH\000\022 \n\nquat_v"
-  "alue\030\013 \001(\0132\n.wire.QuatH\000\022 \n\naabb_value\030\014"
-  " \001(\0132\n.wire.AABBH\000\022\"\n\013basis_value\030\r \001(\0132"
-  "\013.wire.BasisH\000\022*\n\017transform_value\030\016 \001(\0132"
-  "\017.wire.TransformH\000\0221\n\023variant_array_valu"
-  "e\030\017 \001(\0132\022.wire.VariantArrayH\000\022$\n\014object_"
-  "value\030\020 \001(\0132\014.wire.ObjectH\000B\006\n\004type\"(\n\013R"
-  "eturnValue\022\031\n\004data\030\001 \001(\0132\013.wire.Value\"%\n"
-  "\010FuncArgs\022\031\n\004args\030\001 \003(\0132\013.wire.ValueB\014\n\n"
-  "godot.wireb\006proto3"
+  "VariantArray\"m\n\006Object\022\013\n\003ptr\030\001 \001(\006\022 \n\030e"
+  "ngine_constructor_index\030\002 \001(\005\022\036\n\026user_co"
+  "nstructor_index\030\003 \001(\005\022\024\n\014is_user_type\030\004 "
+  "\001(\010\"\263\004\n\005Value\022\023\n\tnil_value\030\001 \001(\005H\000\022\024\n\nbo"
+  "ol_value\030\002 \001(\010H\000\022\024\n\nlong_value\030\003 \001(\003H\000\022\024"
+  "\n\nreal_value\030\004 \001(\001H\000\022\026\n\014string_value\030\005 \001"
+  "(\tH\000\022&\n\rvector2_value\030\006 \001(\0132\r.wire.Vecto"
+  "r2H\000\022\"\n\013rect2_value\030\007 \001(\0132\013.wire.Rect2H\000"
+  "\022&\n\rvector3_value\030\010 \001(\0132\r.wire.Vector3H\000"
+  "\022.\n\021transform2D_value\030\t \001(\0132\021.wire.Trans"
+  "form2DH\000\022\"\n\013plane_value\030\n \001(\0132\013.wire.Pla"
+  "neH\000\022 \n\nquat_value\030\013 \001(\0132\n.wire.QuatH\000\022 "
+  "\n\naabb_value\030\014 \001(\0132\n.wire.AABBH\000\022\"\n\013basi"
+  "s_value\030\r \001(\0132\013.wire.BasisH\000\022*\n\017transfor"
+  "m_value\030\016 \001(\0132\017.wire.TransformH\000\0221\n\023vari"
+  "ant_array_value\030\017 \001(\0132\022.wire.VariantArra"
+  "yH\000\022$\n\014object_value\030\020 \001(\0132\014.wire.ObjectH"
+  "\000B\006\n\004type\"(\n\013ReturnValue\022\031\n\004data\030\001 \001(\0132\013"
+  ".wire.Value\"%\n\010FuncArgs\022\031\n\004args\030\001 \003(\0132\013."
+  "wire.ValueB\014\n\ngodot.wireb\006proto3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_wire_2eproto_deps[1] = {
 };
@@ -526,7 +529,7 @@ static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_wir
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_wire_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_wire_2eproto = {
-  false, false, descriptor_table_protodef_wire_2eproto, "wire.proto", 1338,
+  false, false, descriptor_table_protodef_wire_2eproto, "wire.proto", 1392,
   &descriptor_table_wire_2eproto_once, descriptor_table_wire_2eproto_sccs, descriptor_table_wire_2eproto_deps, 14, 0,
   schemas, file_default_instances, TableStruct_wire_2eproto::offsets,
   file_level_metadata_wire_2eproto, 14, file_level_enum_descriptors_wire_2eproto, file_level_service_descriptors_wire_2eproto,
@@ -3112,15 +3115,15 @@ Object::Object(const Object& from)
   : ::PROTOBUF_NAMESPACE_ID::Message() {
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
   ::memcpy(&ptr_, &from.ptr_,
-    static_cast<size_t>(reinterpret_cast<char*>(&engine_constructor_index_) -
-    reinterpret_cast<char*>(&ptr_)) + sizeof(engine_constructor_index_));
+    static_cast<size_t>(reinterpret_cast<char*>(&is_user_type_) -
+    reinterpret_cast<char*>(&ptr_)) + sizeof(is_user_type_));
   // @@protoc_insertion_point(copy_constructor:wire.Object)
 }
 
 void Object::SharedCtor() {
   ::memset(&ptr_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&engine_constructor_index_) -
-      reinterpret_cast<char*>(&ptr_)) + sizeof(engine_constructor_index_));
+      reinterpret_cast<char*>(&is_user_type_) -
+      reinterpret_cast<char*>(&ptr_)) + sizeof(is_user_type_));
 }
 
 Object::~Object() {
@@ -3155,8 +3158,8 @@ void Object::Clear() {
   (void) cached_has_bits;
 
   ::memset(&ptr_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&engine_constructor_index_) -
-      reinterpret_cast<char*>(&ptr_)) + sizeof(engine_constructor_index_));
+      reinterpret_cast<char*>(&is_user_type_) -
+      reinterpret_cast<char*>(&ptr_)) + sizeof(is_user_type_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -3179,6 +3182,20 @@ const char* Object::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::int
       case 2:
         if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 16)) {
           engine_constructor_index_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // int32 user_constructor_index = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          user_constructor_index_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // bool is_user_type = 4;
+      case 4:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 32)) {
+          is_user_type_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
           CHK_(ptr);
         } else goto handle_unusual;
         continue;
@@ -3222,6 +3239,18 @@ failure:
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(2, this->_internal_engine_constructor_index(), target);
   }
 
+  // int32 user_constructor_index = 3;
+  if (this->user_constructor_index() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(3, this->_internal_user_constructor_index(), target);
+  }
+
+  // bool is_user_type = 4;
+  if (this->is_user_type() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteBoolToArray(4, this->_internal_is_user_type(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -3248,6 +3277,18 @@ size_t Object::ByteSizeLong() const {
     total_size += 1 +
       ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
         this->_internal_engine_constructor_index());
+  }
+
+  // int32 user_constructor_index = 3;
+  if (this->user_constructor_index() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_user_constructor_index());
+  }
+
+  // bool is_user_type = 4;
+  if (this->is_user_type() != 0) {
+    total_size += 1 + 1;
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -3287,6 +3328,12 @@ void Object::MergeFrom(const Object& from) {
   if (from.engine_constructor_index() != 0) {
     _internal_set_engine_constructor_index(from._internal_engine_constructor_index());
   }
+  if (from.user_constructor_index() != 0) {
+    _internal_set_user_constructor_index(from._internal_user_constructor_index());
+  }
+  if (from.is_user_type() != 0) {
+    _internal_set_is_user_type(from._internal_is_user_type());
+  }
 }
 
 void Object::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
@@ -3311,8 +3358,8 @@ void Object::InternalSwap(Object* other) {
   using std::swap;
   _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(Object, engine_constructor_index_)
-      + sizeof(Object::engine_constructor_index_)
+      PROTOBUF_FIELD_OFFSET(Object, is_user_type_)
+      + sizeof(Object::is_user_type_)
       - PROTOBUF_FIELD_OFFSET(Object, ptr_)>(
           reinterpret_cast<char*>(&ptr_),
           reinterpret_cast<char*>(&other->ptr_));

--- a/src/wire/wire.pb.h
+++ b/src/wire/wire.pb.h
@@ -1861,6 +1861,8 @@ class Object PROTOBUF_FINAL :
   enum : int {
     kPtrFieldNumber = 1,
     kEngineConstructorIndexFieldNumber = 2,
+    kUserConstructorIndexFieldNumber = 3,
+    kIsUserTypeFieldNumber = 4,
   };
   // fixed64 ptr = 1;
   void clear_ptr();
@@ -1880,6 +1882,24 @@ class Object PROTOBUF_FINAL :
   void _internal_set_engine_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value);
   public:
 
+  // int32 user_constructor_index = 3;
+  void clear_user_constructor_index();
+  ::PROTOBUF_NAMESPACE_ID::int32 user_constructor_index() const;
+  void set_user_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_user_constructor_index() const;
+  void _internal_set_user_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // bool is_user_type = 4;
+  void clear_is_user_type();
+  bool is_user_type() const;
+  void set_is_user_type(bool value);
+  private:
+  bool _internal_is_user_type() const;
+  void _internal_set_is_user_type(bool value);
+  public:
+
   // @@protoc_insertion_point(class_scope:wire.Object)
  private:
   class _Internal;
@@ -1889,6 +1909,8 @@ class Object PROTOBUF_FINAL :
   typedef void DestructorSkippable_;
   ::PROTOBUF_NAMESPACE_ID::uint64 ptr_;
   ::PROTOBUF_NAMESPACE_ID::int32 engine_constructor_index_;
+  ::PROTOBUF_NAMESPACE_ID::int32 user_constructor_index_;
+  bool is_user_type_;
   mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   friend struct ::TableStruct_wire_2eproto;
 };
@@ -4021,6 +4043,46 @@ inline void Object::_internal_set_engine_constructor_index(::PROTOBUF_NAMESPACE_
 inline void Object::set_engine_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value) {
   _internal_set_engine_constructor_index(value);
   // @@protoc_insertion_point(field_set:wire.Object.engine_constructor_index)
+}
+
+// int32 user_constructor_index = 3;
+inline void Object::clear_user_constructor_index() {
+  user_constructor_index_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 Object::_internal_user_constructor_index() const {
+  return user_constructor_index_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 Object::user_constructor_index() const {
+  // @@protoc_insertion_point(field_get:wire.Object.user_constructor_index)
+  return _internal_user_constructor_index();
+}
+inline void Object::_internal_set_user_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  user_constructor_index_ = value;
+}
+inline void Object::set_user_constructor_index(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_user_constructor_index(value);
+  // @@protoc_insertion_point(field_set:wire.Object.user_constructor_index)
+}
+
+// bool is_user_type = 4;
+inline void Object::clear_is_user_type() {
+  is_user_type_ = false;
+}
+inline bool Object::_internal_is_user_type() const {
+  return is_user_type_;
+}
+inline bool Object::is_user_type() const {
+  // @@protoc_insertion_point(field_get:wire.Object.is_user_type)
+  return _internal_is_user_type();
+}
+inline void Object::_internal_set_is_user_type(bool value) {
+  
+  is_user_type_ = value;
+}
+inline void Object::set_is_user_type(bool value) {
+  _internal_set_is_user_type(value);
+  // @@protoc_insertion_point(field_set:wire.Object.is_user_type)
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
Hi! 

I tried to address the following comment in Invocation.kt:
```
//		This will fail with:
//		class godot.Spatial cannot be cast to class godot.tests.Invocation.
...
//	fun hookTwoParam(str: String, inv: Invocation) {
```

I don't know anything about this project or how things are supposed to work. So this PR might be total garbage. But it was a nice way of trying to get to know the code-base. There is probably a much better solution that I didn't think of. If you have time, please point me in the right direction. If not, feel free to send any other issues my way if there are some small things I can help out with.

Running this code produces the expected output of:
```
Hook was called with parameters: My Awesome param !, godot.Spatial@647e447
Hello Invocation!
Hook was called with parameters (invocation): My Awesome param (invocation)!, godot.tests.Invocation@41fbdac4
```

This PR depends on the following change to godot-kotlin-entry-generator: https://github.com/utopia-rise/godot-kotlin-entry-generator/compare/master...totalorder:argument-full-fqdn?expand=1