### PR TITLE
Fix memory leak of KtSignalInfo arguments

### DIFF
--- a/src/kt_signal_info.cpp
+++ b/src/kt_signal_info.cpp
@@ -15,6 +15,12 @@ KtSignalInfo::KtSignalInfo(jni::JObject p_wrapped, jni::JObject& p_class_loader)
     }
 }
 
+KtSignalInfo::~KtSignalInfo() {
+    for (auto i = 0; i < arguments.size(); i++) {
+        delete arguments[i];
+    }
+}
+
 MethodInfo KtSignalInfo::get_member_info() const {
     MethodInfo method_info;
     method_info.name = name;

--- a/src/kt_signal_info.h
+++ b/src/kt_signal_info.h
@@ -8,7 +8,7 @@
 
 struct KtSignalInfo : public JavaInstanceWrapper {
     KtSignalInfo(jni::JObject p_wrapped, jni::JObject& p_class_loader);
-    ~KtSignalInfo() = default;
+    ~KtSignalInfo();
 
     String name;
     List<KtPropertyInfo*> arguments;


### PR DESCRIPTION
This fixes memory leak at engine closing regarding arguments in KtSignalInfo.