### PR TITLE
Hotfix/rename ci build steps

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -58,8 +58,8 @@ jobs:
         with:
           name: osx-editor-debug-app
           path: bin/godot.osx.tools.64
-  test:
-    needs: build
+  test-editor-debug:
+    needs: build-editor-debug
     strategy:
       matrix:
         os: [macos-latest]

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/check-pr-engine-editor-debug-and-tests.yaml'
 
 jobs:
-  build:
+  build-editor-debug:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/check-pr-engine-editor-release.yaml'
 
 jobs:
-  build:
+  build-editor-release:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/check-pr-engine-export-template-debug.yaml'
 
 jobs:
-  build:
+  build-export-debug:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/check-pr-engine-export-template-release.yaml'
 
 jobs:
-  build:
+  build-export-release:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/check-pr-jvm-godot-library.yaml
+++ b/.github/workflows/check-pr-jvm-godot-library.yaml
@@ -9,7 +9,7 @@ on:
       - '.github/workflows/check-pr-jvm-godot-library.yaml'
 
 jobs:
-  build:
+  build-godot-library:
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/check-pr-jvm-gradle-plugin.yaml
+++ b/.github/workflows/check-pr-jvm-gradle-plugin.yaml
@@ -10,7 +10,7 @@ on:
       - '.github/workflows/check-pr-jvm-gradle-plugin.yaml'
 
 jobs:
-  build:
+  build-gradle-plugin:
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
This rename CI stages so that it is easy to read and github identify all build stages.