### PR TITLE
Feature/handling singletons

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -1,4 +1,3 @@
-
 package godot.tests
 
 import godot.ARVRServer
@@ -71,8 +70,8 @@ class Invocation : Spatial() {
 
     @RegisterProperty
     var nullableDictionary = dictionaryOf(
-            "notnull" to NavigationMesh(),
-            "null" to null
+        "notnull" to NavigationMesh(),
+        "null" to null
     )
 
     @RegisterProperty
@@ -165,10 +164,10 @@ class Invocation : Spatial() {
     @RegisterProperty
     @MultilineText
     var p15 = """
-        some
-        multiline
-        text
-    """.trimIndent()
+		some
+		multiline
+		text
+	""".trimIndent()
 
     @RegisterProperty
     @PlaceHolderText
@@ -243,7 +242,6 @@ class Invocation : Spatial() {
 
     override fun _onInit() {
         println("Hello Invocation!")
-        println("ARVR server is: ${ARVRServer.getInstanceId()}")
     }
 
     override fun _onDestroy() {
@@ -456,4 +454,10 @@ class Invocation : Spatial() {
 
     @RegisterFunction
     fun getVector3FromPoolArray(index: Int) = poolVector3Array[index]
+
+    // Singleton tests
+
+    @RegisterFunction
+    fun isSentArvrSameInstanceAsJvmSingleton(arvrServer: ARVRServer) =
+        ARVRServer.getInstanceId() == arvrServer.getInstanceId()
 }

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -1,6 +1,7 @@
 
 package godot.tests
 
+import godot.ARVRServer
 import godot.NavigationMesh
 import godot.Object
 import godot.Spatial
@@ -242,6 +243,7 @@ class Invocation : Spatial() {
 
     override fun _onInit() {
         println("Hello Invocation!")
+        println("ARVR server is: ${ARVRServer.getInstanceId()}")
     }
 
     override fun _onDestroy() {

--- a/harness/tests/test/unit/test_singletons.gd
+++ b/harness/tests/test/unit/test_singletons.gd
@@ -1,0 +1,7 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_singleton_same_instance() -> void:
+	var invocation = load("res://src/main/kotlin/godot/tests/Invocation.kt").new()
+	assert_true(invocation.is_sent_arvr_same_instance_as_jvm_singleton(ARVRServer), "Should be same instance")
+	invocation.free()

--- a/kt/godot-library/src/main/kotlin/godot/EngineIndex.kt
+++ b/kt/godot-library/src/main/kotlin/godot/EngineIndex.kt
@@ -8,6 +8,7 @@ const val SPATIAL = 2
 const val REFERENCE = 3
 const val RESOURCE = 4
 const val NAVIGATION_MESH = 5
+const val ARVR_SERVER = 6
 
 
 // Methods

--- a/kt/godot-library/src/main/kotlin/godot/tests.kt
+++ b/kt/godot-library/src/main/kotlin/godot/tests.kt
@@ -6,9 +6,9 @@ import godot.util.VoidPtr
 import godot.util.camelToSnakeCase
 import kotlin.reflect.KCallable
 
-open class Object(isRef: Boolean = false) : KtObject(isRef) {
+open class Object internal constructor(isRef: Boolean = false, isSingleton: Boolean = false) : KtObject(isRef, isSingleton) {
 
-    constructor() : this(false)
+    constructor() : this(false, false)
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(OBJECT)
@@ -316,7 +316,10 @@ open class Object(isRef: Boolean = false) : KtObject(isRef) {
     }
 }
 
-open class Node : Object() {
+open class Node internal constructor(isSingleton: Boolean): Object(isSingleton = isSingleton){
+
+    constructor() : this(false)
+
     open var name: String
         get() {
             TransferContext.writeArguments()
@@ -362,20 +365,28 @@ open class Node : Object() {
     }
 }
 
-open class Spatial : Node() {
+open class Spatial internal constructor(isSingleton: Boolean) : Node(isSingleton = isSingleton) {
+
+    constructor() : this(false)
+
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(SPATIAL)
     }
 }
 
-open class Reference : Object(true) {
+open class Reference internal constructor(isSingleton: Boolean) : Object(true, isSingleton) {
+
+    constructor() : this(false)
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(REFERENCE)
     }
 }
 
-open class Resource : Reference() {
+open class Resource internal constructor(isSingleton: Boolean): Reference(isSingleton = isSingleton) {
+
+    constructor() : this(false)
+
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(RESOURCE)
     }
@@ -386,14 +397,16 @@ open class Resource : Reference() {
     }
 }
 
-open class NavigationMesh : Resource() {
+open class NavigationMesh internal constructor(isSingleton: Boolean) : Resource(isSingleton = isSingleton) {
+
+    constructor() : this(false)
+
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(NAVIGATION_MESH)
     }
 }
 
-object ARVRServer : Object() {
-    override fun isSingleton() = true
+object ARVRServer : Object(isSingleton = true) {
     override fun __new(): VoidPtr {
         return TransferContext.getSingleton(ARVR_SERVER)
     }

--- a/kt/godot-library/src/main/kotlin/godot/tests.kt
+++ b/kt/godot-library/src/main/kotlin/godot/tests.kt
@@ -6,9 +6,7 @@ import godot.util.VoidPtr
 import godot.util.camelToSnakeCase
 import kotlin.reflect.KCallable
 
-open class Object internal constructor(isRef: Boolean = false, isSingleton: Boolean = false) : KtObject(isRef, isSingleton) {
-
-    constructor() : this(false, false)
+open class Object : KtObject() {
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(OBJECT)
@@ -316,9 +314,7 @@ open class Object internal constructor(isRef: Boolean = false, isSingleton: Bool
     }
 }
 
-open class Node internal constructor(isSingleton: Boolean): Object(isSingleton = isSingleton){
-
-    constructor() : this(false)
+open class Node : Object() {
 
     open var name: String
         get() {
@@ -365,27 +361,23 @@ open class Node internal constructor(isSingleton: Boolean): Object(isSingleton =
     }
 }
 
-open class Spatial internal constructor(isSingleton: Boolean) : Node(isSingleton = isSingleton) {
-
-    constructor() : this(false)
+open class Spatial : Node() {
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(SPATIAL)
     }
 }
 
-open class Reference internal constructor(isSingleton: Boolean) : Object(true, isSingleton) {
-
-    constructor() : this(false)
+open class Reference : Object() {
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(REFERENCE)
     }
+
+    override fun ____DO_NOT_TOUCH_THIS_isRef____() = true
 }
 
-open class Resource internal constructor(isSingleton: Boolean): Reference(isSingleton = isSingleton) {
-
-    constructor() : this(false)
+open class Resource : Reference() {
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(RESOURCE)
@@ -397,19 +389,19 @@ open class Resource internal constructor(isSingleton: Boolean): Reference(isSing
     }
 }
 
-open class NavigationMesh internal constructor(isSingleton: Boolean) : Resource(isSingleton = isSingleton) {
-
-    constructor() : this(false)
+open class NavigationMesh : Resource() {
 
     override fun __new(): VoidPtr {
         return TransferContext.invokeConstructor(NAVIGATION_MESH)
     }
 }
 
-object ARVRServer : Object(isSingleton = true) {
+object ARVRServer : Object() {
     override fun __new(): VoidPtr {
         return TransferContext.getSingleton(ARVR_SERVER)
     }
+
+    override fun ____DO_NOT_TOUCH_THIS_isSingleton____() = true
 }
 
 fun registerVariantMapping() {

--- a/kt/godot-library/src/main/kotlin/godot/tests.kt
+++ b/kt/godot-library/src/main/kotlin/godot/tests.kt
@@ -392,6 +392,12 @@ open class NavigationMesh : Resource() {
     }
 }
 
+object ARVRServer : Object() {
+    override fun __new(): VoidPtr {
+        return TransferContext.getSingleton(ARVR_SERVER)
+    }
+}
+
 fun registerVariantMapping() {
     variantMapper[Object::class] = VariantType.OBJECT
     variantMapper[Node::class] = VariantType.OBJECT
@@ -399,6 +405,7 @@ fun registerVariantMapping() {
     variantMapper[Reference::class] = VariantType.OBJECT
     variantMapper[Resource::class] = VariantType.OBJECT
     variantMapper[NavigationMesh::class] = VariantType.OBJECT
+    variantMapper[ARVRServer::class] = VariantType.OBJECT
 }
 
 fun registerEngineTypes() {
@@ -408,6 +415,7 @@ fun registerEngineTypes() {
     TypeManager.registerEngineType("Reference", ::Reference)
     TypeManager.registerEngineType("Resource", ::Resource)
     TypeManager.registerEngineType("NavigationMesh", ::NavigationMesh)
+    TypeManager.registerEngineType("ARVRServer") { ARVRServer }
 }
 
 fun registerEngineTypeMethods() {

--- a/kt/godot-library/src/main/kotlin/godot/tests.kt
+++ b/kt/godot-library/src/main/kotlin/godot/tests.kt
@@ -393,6 +393,7 @@ open class NavigationMesh : Resource() {
 }
 
 object ARVRServer : Object() {
+    override fun isSingleton() = true
     override fun __new(): VoidPtr {
         return TransferContext.getSingleton(ARVR_SERVER)
     }

--- a/kt/godot-runtime/src/main/kotlin/godot/core/GarbageCollector.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/GarbageCollector.kt
@@ -28,7 +28,7 @@ object GarbageCollector {
 
     fun registerInstance(instance: KtObject) {
         val rawPtr = instance.rawPtr
-        if (instance.isRef) {
+        if (instance.____DO_NOT_TOUCH_THIS_isRef____()) {
             synchronized(refWrappedMap) {
                 refWrappedMap[rawPtr] = WeakReference(instance)
                 MemoryBridge.ref(rawPtr)

--- a/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
@@ -4,7 +4,7 @@ import godot.util.VoidPtr
 import godot.util.nullptr
 
 @Suppress("LeakingThis")
-abstract class KtObject(internal val isRef: Boolean, private val isSingleton: Boolean) : AutoCloseable {
+abstract class KtObject : AutoCloseable {
     var rawPtr: VoidPtr = nullptr
         set(value) {
             require(field == nullptr) {
@@ -22,7 +22,7 @@ abstract class KtObject(internal val isRef: Boolean, private val isSingleton: Bo
                 rawPtr = __new()
                 godotInstanceId = getInstanceId()
 
-                if (!isSingleton) {
+                if (!____DO_NOT_TOUCH_THIS_isSingleton____()) {
                     GarbageCollector.registerInstance(this)
                 }
 
@@ -40,6 +40,12 @@ abstract class KtObject(internal val isRef: Boolean, private val isSingleton: Bo
             shouldInit.set(true)
         }
     }
+
+    @Suppress("FunctionName")
+    open fun ____DO_NOT_TOUCH_THIS_isRef____() = false
+
+    @Suppress("FunctionName")
+    open fun ____DO_NOT_TOUCH_THIS_isSingleton____() = false
 
     abstract fun __new(): VoidPtr
     abstract fun getInstanceId(): Long
@@ -63,7 +69,7 @@ abstract class KtObject(internal val isRef: Boolean, private val isSingleton: Bo
             return constructor().also {
                 it.rawPtr = rawPtr
                 it.godotInstanceId = instanceId
-                if (!it.isSingleton) {
+                if (!it.____DO_NOT_TOUCH_THIS_isSingleton____()) {
                     GarbageCollector.registerInstance(it)
                 }
                 it._onInit()

--- a/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
@@ -21,7 +21,10 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
                 // user types shouldn't override this method
                 rawPtr = __new()
                 godotInstanceId = getInstanceId()
-                GarbageCollector.registerInstance(this)
+
+                if (!isSingleton()) {
+                    GarbageCollector.registerInstance(this)
+                }
 
                 // inheritance in Godot is faked, a script is attached to an Object allow
                 // the script to see all methods of the owning Object.
@@ -40,6 +43,8 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
 
     abstract fun __new(): VoidPtr
     abstract fun getInstanceId(): Long
+
+    open fun isSingleton() = false
 
     open fun _onInit() = Unit
     open fun _onDestroy() = Unit
@@ -60,7 +65,9 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
             return constructor().also {
                 it.rawPtr = rawPtr
                 it.godotInstanceId = instanceId
-                GarbageCollector.registerInstance(it)
+                if (!it.isSingleton()) {
+                    GarbageCollector.registerInstance(it)
+                }
                 it._onInit()
             }
         }

--- a/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
@@ -4,7 +4,7 @@ import godot.util.VoidPtr
 import godot.util.nullptr
 
 @Suppress("LeakingThis")
-abstract class KtObject(val isRef: Boolean) : AutoCloseable {
+abstract class KtObject(val isRef: Boolean, private val isSingleton: Boolean) : AutoCloseable {
     var rawPtr: VoidPtr = nullptr
         set(value) {
             require(field == nullptr) {
@@ -22,7 +22,7 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
                 rawPtr = __new()
                 godotInstanceId = getInstanceId()
 
-                if (!isSingleton()) {
+                if (!isSingleton) {
                     GarbageCollector.registerInstance(this)
                 }
 
@@ -44,8 +44,6 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
     abstract fun __new(): VoidPtr
     abstract fun getInstanceId(): Long
 
-    open fun isSingleton() = false
-
     open fun _onInit() = Unit
     open fun _onDestroy() = Unit
 
@@ -65,7 +63,7 @@ abstract class KtObject(val isRef: Boolean) : AutoCloseable {
             return constructor().also {
                 it.rawPtr = rawPtr
                 it.godotInstanceId = instanceId
-                if (!it.isSingleton()) {
+                if (!it.isSingleton) {
                     GarbageCollector.registerInstance(it)
                 }
                 it._onInit()

--- a/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/KtObject.kt
@@ -4,7 +4,7 @@ import godot.util.VoidPtr
 import godot.util.nullptr
 
 @Suppress("LeakingThis")
-abstract class KtObject(val isRef: Boolean, private val isSingleton: Boolean) : AutoCloseable {
+abstract class KtObject(internal val isRef: Boolean, private val isSingleton: Boolean) : AutoCloseable {
     var rawPtr: VoidPtr = nullptr
         set(value) {
             require(field == nullptr) {

--- a/kt/godot-runtime/src/main/kotlin/godot/core/TransferContext.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/TransferContext.kt
@@ -51,6 +51,7 @@ object TransferContext {
 
     external fun setScript(rawPtr: VoidPtr, className: String, obj: KtObject, classLoader: ClassLoader);
     external fun invokeConstructor(classIndex: Int): VoidPtr
+    external fun getSingleton(classIndex: Int): VoidPtr
     external fun freeObject(rawPtr: VoidPtr)
 
     private external fun icall(ptr: VoidPtr, methodIndex: Int, expectedReturnType: Int)

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Variant.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Variant.kt
@@ -305,7 +305,7 @@ enum class VariantType(
                 buffer.variantType = OBJECT.ordinal
                 any as KtObject
                 buffer.putLong(any.rawPtr)
-                buffer.bool = any.isRef
+                buffer.bool = any.____DO_NOT_TOUCH_THIS_isRef____()
             }
     ),
     DICTIONARY(

--- a/src/transfer_context.cpp
+++ b/src/transfer_context.cpp
@@ -24,6 +24,12 @@ TransferContext::TransferContext(jni::JObject p_wrapped, jni::JObject p_class_lo
             (void*) TransferContext::invoke_constructor
     };
 
+    jni::JNativeMethod get_singleton_method{
+            "getSingleton",
+            "(I)J",
+            (void*) TransferContext::get_singleton
+    };
+
     jni::JNativeMethod set_script_method{
             "setScript",
             "(JLjava/lang/String;Lgodot/core/KtObject;Ljava/lang/ClassLoader;)V",
@@ -39,6 +45,7 @@ TransferContext::TransferContext(jni::JObject p_wrapped, jni::JObject p_class_lo
     Vector<jni::JNativeMethod> methods;
     methods.push_back(icall_method);
     methods.push_back(invoke_ctor_method);
+    methods.push_back(get_singleton_method);
     methods.push_back(set_script_method);
     methods.push_back(free_object_method);
     jni::Env env {jni::Jvm::current_env()};
@@ -149,6 +156,14 @@ jlong TransferContext::invoke_constructor(JNIEnv *p_raw_env, jobject p_instance,
 #endif
 
     return reinterpret_cast<uintptr_t>(ptr);
+}
+
+jlong TransferContext::get_singleton(JNIEnv* p_raw_env, jobject p_instance, jint p_class_index) {
+    return reinterpret_cast<uintptr_t>(
+            Engine::get_singleton()->get_singleton_object(
+                    GDKotlin::get_instance().engine_type_names[static_cast<int>(p_class_index)]
+            )
+    );
 }
 
 void TransferContext::set_script(JNIEnv *p_raw_env, jobject p_instance, jlong p_raw_ptr, jstring p_class_name,

--- a/src/transfer_context.h
+++ b/src/transfer_context.h
@@ -24,6 +24,7 @@ public:
     static void icall(JNIEnv* rawEnv, jobject instance, jlong jPtr, jint p_method_index, jint expectedReturnType);
 
     static jlong invoke_constructor(JNIEnv* p_raw_env, jobject p_instance, jint p_class_index);
+    static jlong get_singleton(JNIEnv* p_raw_env, jobject p_instance, jint p_class_index);
     static void set_script(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr, jstring p_class_name, jobject p_object,
                            jobject p_class_loader);
     static void free_object(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr);


### PR DESCRIPTION
This adds a method to retrieve singleton pointers from engine.
This adds private to `KtObject` field `isSingleton` to avoid singleton registering in GC.