### PR TITLE
Implement support for custom srcDirs

### DIFF
--- a/harness/tests/CustomSrcDirTest.tscn
+++ b/harness/tests/CustomSrcDirTest.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=2]
 
-[ext_resource path="res://scripts/TestScript.kt" type="Script" id=1]
+[ext_resource path="res://scripts/ScriptInCustomSourceDir.kt" type="Script" id=1]
 
 [node name="CustomSrcDirTest" type="Node2D"]
 script = ExtResource( 1 )

--- a/harness/tests/CustomSrcDirTest.tscn
+++ b/harness/tests/CustomSrcDirTest.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/TestScript.kt" type="Script" id=1]
+
+[node name="CustomSrcDirTest" type="Node2D"]
+script = ExtResource( 1 )

--- a/harness/tests/Spatial.tscn
+++ b/harness/tests/Spatial.tscn
@@ -1,10 +1,32 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://src/main/kotlin/godot/tests/Invocation.kt" type="Script" id=1]
 
+[sub_resource type="NavigationMesh" id=1]
+
+[sub_resource type="NavigationMesh" id=2]
+
+[sub_resource type="NavigationMesh" id=3]
+
+[sub_resource type="NavigationMesh" id=4]
+
+[sub_resource type="NavigationMesh" id=5]
+
 [node name="Spatial" type="Spatial"]
 script = ExtResource( 1 )
-enum_test = 0
+nullable_dictionary = {
+"notnull": SubResource( 1 ),
+"null": null
+}
+nullable_array = [ SubResource( 2 ), null ]
+nav_meshes_dictionary = {
+"AwesomeNavmesh": SubResource( 3 )
+}
+any_to_any_dictionary = {
+}
+resource_test = SubResource( 4 )
+nav_meshes = [ SubResource( 5 ) ]
+jvm_id = 2009221452
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.974354, 0.225019, 0, -0.225019, 0.974354, 0, 1.2131, 2.47241 )

--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -1,4 +1,3 @@
-
 plugins {
     kotlin("jvm") version "1.4.10"
     id("com.utopia-rise.godot-jvm") version "0.1.0-3.2"
@@ -6,6 +5,12 @@ plugins {
 
 repositories {
     jcenter()
+}
+
+kotlin {
+    sourceSets.main {
+        kotlin.srcDir("scripts")
+    }
 }
 
 dependencies {

--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -10,18 +10,36 @@ config_version=4
 
 _global_script_classes=[ {
 "base": "Node",
-"class": "TestScript",
+"class": "ScriptInCustomSourceDir",
 "language": "Kotlin",
-"path": "res://scripts/TestScript.kt"
+"path": "res://scripts/ScriptInCustomSourceDir.kt"
 }, {
 "base": "Spatial",
 "class": "godot_tests_Invocation",
 "language": "Kotlin",
 "path": "res://src/main/kotlin/godot/tests/Invocation.kt"
+}, {
+"base": "Node",
+"class": "godot_tests_inheritance_ClassInheritanceChild",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceChild.kt"
+}, {
+"base": "Node",
+"class": "godot_tests_inheritance_ClassInheritanceParent",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceParent.kt"
+}, {
+"base": "Node",
+"class": "godot_tests_subpackage_OtherScript",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/subpackage/OtherScript.kt"
 } ]
 _global_script_class_icons={
-"TestScript": "",
-"godot_tests_Invocation": ""
+"ScriptInCustomSourceDir": "",
+"godot_tests_Invocation": "",
+"godot_tests_inheritance_ClassInheritanceChild": "",
+"godot_tests_inheritance_ClassInheritanceParent": "",
+"godot_tests_subpackage_OtherScript": ""
 }
 
 [application]

--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -9,31 +9,19 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Node",
+"class": "TestScript",
+"language": "Kotlin",
+"path": "res://scripts/TestScript.kt"
+}, {
 "base": "Spatial",
 "class": "godot_tests_Invocation",
 "language": "Kotlin",
 "path": "res://src/main/kotlin/godot/tests/Invocation.kt"
-}, {
-"base": "Node",
-"class": "godot_tests_inheritance_ClassInheritanceChild",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceChild.kt"
-}, {
-"base": "Node",
-"class": "godot_tests_inheritance_ClassInheritanceParent",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceParent.kt"
-}, {
-"base": "Node",
-"class": "godot_tests_subpackage_OtherScript",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/tests/subpackage/OtherScript.kt"
 } ]
 _global_script_class_icons={
-"godot_tests_Invocation": "",
-"godot_tests_inheritance_ClassInheritanceChild": "",
-"godot_tests_inheritance_ClassInheritanceParent": "",
-"godot_tests_subpackage_OtherScript": ""
+"TestScript": "",
+"godot_tests_Invocation": ""
 }
 
 [application]

--- a/harness/tests/scripts/ScriptInCustomSourceDir.kt
+++ b/harness/tests/scripts/ScriptInCustomSourceDir.kt
@@ -3,7 +3,7 @@ import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 
 @RegisterClass
-class TestScript : Node() {
+class ScriptInCustomSourceDir : Node() {
 
     @RegisterFunction
     fun _ready() {

--- a/harness/tests/scripts/TestScript.kt
+++ b/harness/tests/scripts/TestScript.kt
@@ -1,0 +1,12 @@
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+
+@RegisterClass
+class TestScript : Node() {
+
+    @RegisterFunction
+    fun _ready() {
+        println("Juhuu this just works!")
+    }
+}

--- a/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -117,9 +117,6 @@ class GodotAnnotationProcessor(
     }
 
     override fun processingOver() {
-        File(entryGenerationOutputDir).mkdirs()
-        File("$entryGenerationOutputDir/debug.txt").appendText(classes.map { it.name }.joinToString("\n"))
-
         deleteObsoleteClassSpecificEntryFiles()
         EntryGenerator.psiClassesWithMembers = getAllRegisteredUserPsiClassesWithMembers()
         EntryGenerator.generateEntryFiles(
@@ -129,7 +126,15 @@ class GodotAnnotationProcessor(
             classes,
             properties,
             functions,
-            signals
+            signals,
+            srcDirs
+                .map {
+                    it
+                        .absolutePath
+                        .removePrefix(File(entryGenerationOutputDir).parentFile.parentFile.absolutePath)
+                        .removePrefix("/")
+                        .let { path -> "$path/" }
+                }
         )
         EntryGenerator.generateServiceFile(serviceFileOutputDir)
     }

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -83,6 +83,7 @@ class Bootstrap {
                         TypeManager.engineTypeMethod.map { it.first }.toTypedArray()
                 )
                 context.init()
+                registerSrcDirs(provideSrcDirs().toTypedArray())
             }
             loadClasses(registry.classes.toTypedArray())
         } else {
@@ -90,6 +91,7 @@ class Bootstrap {
         }
     }
 
+    private external fun registerSrcDirs(srcDirs: Array<String>)
     private external fun loadClasses(classes: Array<KtClass<*>>)
     private external fun unloadClasses(classes: Array<KtClass<*>>)
 

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Entry.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Entry.kt
@@ -4,4 +4,5 @@ abstract class Entry {
     class Context(val registry: ClassRegistry)
     abstract fun Context.init()
     abstract fun Context.initEngineTypes()
+    abstract fun provideSrcDirs(): List<String>
 }

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -9,12 +9,12 @@ Bootstrap::Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader) : Java
 }
 
 void
-Bootstrap::register_hooks(jni::Env& p_env, ProvideSrcDirsHook p_provide_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
+Bootstrap::register_hooks(jni::Env& p_env, RegisterSrcDirsHook p_register_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                           RegisterManagedEngineTypes p_register_managed_engine_types_hook) {
     jni::JNativeMethod provide_src_dirs_hook_method {
             "registerSrcDirs",
             "([Ljava/lang/String;)V",
-            (void*) p_provide_src_dirs_hook
+            (void*) p_register_src_dirs_hook
     };
 
     jni::JNativeMethod load_class_hook_method {

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -9,8 +9,14 @@ Bootstrap::Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader) : Java
 }
 
 void
-Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
+Bootstrap::register_hooks(jni::Env& p_env, ProvideSrcDirsHook p_provide_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                           RegisterManagedEngineTypes p_register_managed_engine_types_hook) {
+    jni::JNativeMethod provide_src_dirs_hook_method {
+            "registerSrcDirs",
+            "([Ljava/lang/String;)V",
+            (void*) p_provide_src_dirs_hook
+    };
+
     jni::JNativeMethod load_class_hook_method {
             "loadClasses",
             "([Lgodot/core/KtClass;)V",
@@ -30,6 +36,7 @@ Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, 
     };
 
     Vector<jni::JNativeMethod> methods;
+    methods.push_back(provide_src_dirs_hook_method);
     methods.push_back(load_class_hook_method);
     methods.push_back(unload_class_hook_method);
     methods.push_back(register_managed_engine_types_method);

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -6,7 +6,7 @@
 
 class Bootstrap : public JavaInstanceWrapper<Bootstrap> {
 public:
-    typedef void (*ProvideSrcDirsHook)(JNIEnv* p_env, jobject p_this, jobjectArray src_dirs);
+    typedef void (*RegisterSrcDirsHook)(JNIEnv* p_env, jobject p_this, jobjectArray src_dirs);
     typedef void (*LoadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*UnloadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*RegisterManagedEngineTypes)(JNIEnv* p_env, jobject p_this, jobjectArray classes_names,
@@ -15,7 +15,7 @@ public:
     Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader);
     ~Bootstrap() = default;
 
-    void register_hooks(jni::Env& p_env, ProvideSrcDirsHook p_provide_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
+    void register_hooks(jni::Env& p_env, RegisterSrcDirsHook p_register_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                         RegisterManagedEngineTypes p_register_managed_engine_types_hook);
     void init(jni::Env& env, bool p_is_editor, const String& p_project_dir);
     void finish(jni::Env& p_env);

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -6,6 +6,7 @@
 
 class Bootstrap : public JavaInstanceWrapper<Bootstrap> {
 public:
+    typedef void (*ProvideSrcDirsHook)(JNIEnv* p_env, jobject p_this, jobjectArray src_dirs);
     typedef void (*LoadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*UnloadClassesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes);
     typedef void (*RegisterManagedEngineTypes)(JNIEnv* p_env, jobject p_this, jobjectArray classes_names,
@@ -14,7 +15,7 @@ public:
     Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader);
     ~Bootstrap() = default;
 
-    void register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
+    void register_hooks(jni::Env& p_env, ProvideSrcDirsHook p_provide_src_dirs_hook, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                         RegisterManagedEngineTypes p_register_managed_engine_types_hook);
     void init(jni::Env& env, bool p_is_editor, const String& p_project_dir);
     void finish(jni::Env& p_env);

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -64,7 +64,7 @@ void load_classes_hook(JNIEnv* p_env, jobject p_this, jobjectArray p_classes) {
     classes.delete_local_ref(env);
 }
 
-void provide_src_dirs_hook(JNIEnv* p_env, jobject p_this, jobjectArray p_src_dirs) {
+void register_src_dirs_hook(JNIEnv* p_env, jobject p_this, jobjectArray p_src_dirs) {
     jni::Env env(p_env);
     jni::JObjectArray src_dirs_raw{jni::JObjectArray(p_src_dirs)};
     Vector<String> src_dirs{};
@@ -267,7 +267,8 @@ void GDKotlin::init() {
     jni::MethodId ctor = bootstrap_cls.get_constructor_method_id(env, "()V");
     jni::JObject instance = bootstrap_cls.new_instance(env, ctor);
     bootstrap = new Bootstrap(instance, class_loader);
-    bootstrap->register_hooks(env, provide_src_dirs_hook, load_classes_hook, unload_classes_hook, register_engine_types_hook);
+    bootstrap->register_hooks(env, register_src_dirs_hook, load_classes_hook, unload_classes_hook,
+                              register_engine_types_hook);
     bool is_editor = Engine::get_singleton()->is_editor_hint();
     String project_path = project_settings->globalize_path("res://");
 

--- a/src/gd_kotlin.h
+++ b/src/gd_kotlin.h
@@ -22,7 +22,7 @@ private:
 
     Error split_jvm_debug_argument(const String& cmd_arg, String& result);
 public:
-    String scripts_root;
+    Vector<String> scripts_root;
     TransferContext* transfer_context;
     Vector<StringName> engine_type_names;
     Vector<MethodBind*> engine_type_method;

--- a/src/kotlin_language.cpp
+++ b/src/kotlin_language.cpp
@@ -201,9 +201,6 @@ String KotlinLanguage::validate_path(const String& p_path) const {
     if (keywords.find(p_path.get_file().get_basename())) {
         return TTR("Please don't use reserved keywords as file name.");
     }
-    if (!p_path.begins_with(GDKotlin::get_instance().scripts_root)) {
-        return TTR("Kotlin classes must be placed at src/main/kotlin.");
-    }
     return "";
 }
 


### PR DESCRIPTION
This implements the support to define other source dirs than `src/main/kotlin` and write and use scripts from them.
The source dirs are now also written to the entry file and retreived by cpp when searching a class (similar like before but before, the source dir was hardcoded in cpp)

Entry file:
```kotlin
class Entry : Entry() {
  override fun Context.init() {
    TestScriptRegistrar().register(registry)
    InvocationRegistrar().register(registry)
    ClassInheritanceChildRegistrar().register(registry)
    ClassInheritanceParentRegistrar().register(registry)
    OtherScriptRegistrar().register(registry)
  }

  override fun Context.initEngineTypes() {
    registerVariantMapping()
    registerEngineTypes()
    registerEngineTypeMethods()
  }

  override fun provideSrcDirs() = listOf<String>("src/main/kotlin/", "src/main/java/", "scripts/")
}
```

Please look carefully at the cpp code. As you know i'm by no means a cpp developer.

Depends on: https://github.com/utopia-rise/godot-kotlin-entry-generator/pull/12