### PR TITLE
Fix incremental builds on windows

### DIFF
--- a/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -129,7 +129,7 @@ class GodotAnnotationProcessor(
             properties,
             functions,
             signals,
-            srcDirs.map { it.absolutePath }
+            srcDirs
         )
         EntryGenerator.generateServiceFile(serviceFileOutputDir)
     }

--- a/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -179,9 +179,13 @@ class GodotAnnotationProcessor(
             .walkTopDown()
             .filter { it.isFile && it.exists() && it.extension == "kt" }
             .forEach {
-                val fqName =
-                    it.absolutePath.removePrefix(entryGenerationOutputDir).removePrefix("/godot/").replace("/", ".")
-                        .removeSuffix("Entry.kt")
+                val fqName = it
+                    .absolutePath
+                    .removePrefix(entryGenerationOutputDir)
+                    .removePrefix("${File.separator}godot${File.separator}")
+                    .replace(File.separator, ".")
+                    .removeSuffix("Entry.kt")
+
                 if (!userClassesFqNames.contains(fqName)) {
                     it.delete()
                 }
@@ -212,7 +216,10 @@ class GodotAnnotationProcessor(
                     .map { file ->
                         if (!file.isFile) return@map null
 
-                        val virtualFile = localFileSystem.findFileByPath(file.absolutePath)?.let(virtualFileCreator::create)
+                        val virtualFile = localFileSystem
+                            .findFileByPath(file.absolutePath)
+                            ?.let(virtualFileCreator::create)
+
                         if (virtualFile != null && processedFiles.add(virtualFile)) {
                             val psiFile = psiManager.findFile(virtualFile)
                             if (psiFile is KtFile) {

--- a/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -30,7 +30,7 @@ class GodotAnnotationProcessor(
     private val project: MockProject,
     private val entryGenerationOutputDir: String,
     private val serviceFileOutputDir: String,
-    private val srcDirs: List<File>
+    private val srcDirs: List<String>
 ) : AbstractProcessor() {
     lateinit var bindingContext: BindingContext
     private val userClasses: List<KtClass> = getAllUserDefinedClasses()
@@ -118,7 +118,6 @@ class GodotAnnotationProcessor(
 
     override fun processingOver() {
         File(entryGenerationOutputDir).mkdirs()
-        File("$entryGenerationOutputDir/debug.txt").appendText(classes.map { it.name }.joinToString("\n"))
 
         deleteObsoleteClassSpecificEntryFiles()
         EntryGenerator.psiClassesWithMembers = getAllRegisteredUserPsiClassesWithMembers()
@@ -201,7 +200,6 @@ class GodotAnnotationProcessor(
         //End: taken from CoreEnvironmentUtils createSourceFilesFromSourceRoots inside org.jetbrains.kotlin:kotlin-compiler:1.4.10
 
         return srcDirs
-            .map { it.absolutePath }
             .flatMap { srcDirAbsolutePath ->
                 //Start: taken from CoreEnvironmentUtils createSourceFilesFromSourceRoots inside org.jetbrains.kotlin:kotlin-compiler:1.4.10
                 val vFile = localFileSystem.findFileByPath(srcDirAbsolutePath) ?: return@flatMap emptySequence()

--- a/kt/entry-generation/godot-kotlin-compiler-plugin-common/src/main/kotlin/godot/kotlincompilerplugin/common/CompilerPluginConst.kt
+++ b/kt/entry-generation/godot-kotlin-compiler-plugin-common/src/main/kotlin/godot/kotlincompilerplugin/common/CompilerPluginConst.kt
@@ -1,7 +1,6 @@
 package godot.kotlincompilerplugin.common
 
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import java.io.File
 
 object CompilerPluginConst {
     const val compilerPluginGroupId = "com.utopia-rise"
@@ -21,7 +20,7 @@ object CompilerPluginConst {
             CompilerConfigurationKey.create("path to the folder in which the generated entry file should be written")
         val SERVICE_FILE_DIR_PATH: CompilerConfigurationKey<String> =
             CompilerConfigurationKey.create("path to the folder in which the generated entry file should be written")
-        val SOURCES_DIR_PATH: CompilerConfigurationKey<List<File>> =
+        val SOURCES_DIR_PATH: CompilerConfigurationKey<List<String>> =
             CompilerConfigurationKey.create("paths to the folders in which the kotlin sources reside")
         val ENABLED: CompilerConfigurationKey<Boolean> =
             CompilerConfigurationKey.create("flag to enable entry generation")

--- a/kt/entry-generation/godot-kotlin-compiler-plugin/src/main/kotlin/godot/kotlincompilerplugin/CommonComponentRegistrar.kt
+++ b/kt/entry-generation/godot-kotlin-compiler-plugin/src/main/kotlin/godot/kotlincompilerplugin/CommonComponentRegistrar.kt
@@ -6,7 +6,11 @@ import godot.kotlincompilerplugin.common.CompilerPluginConst
 import org.jetbrains.kotlin.codegen.ClassBuilderFactory
 import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
-import org.jetbrains.kotlin.compiler.plugin.*
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.diagnostics.DiagnosticSink
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
@@ -94,7 +98,7 @@ class CommonGodotKotlinCompilerPluginCommandLineProcessor : CommandLineProcessor
             )
             SOURCES_DIR_PATH_OPTION -> {
                 configuration.put(
-                    CompilerPluginConst.CommandlineArguments.SOURCES_DIR_PATH, value.split(":").map { File(it) }
+                    CompilerPluginConst.CommandlineArguments.SOURCES_DIR_PATH, value.split(File.pathSeparator)
                 )
             }
             ENABLED -> configuration.put(

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
@@ -1,6 +1,7 @@
 package godot.gradle
 
 import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import godot.gradle.util.absolutePathFixedForWindows
 import godot.kotlincompilerplugin.common.CompilerPluginConst
 import godot.utils.GodotBuildProperties
 import org.gradle.api.Project
@@ -8,7 +9,10 @@ import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.plugin.*
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import java.io.File
 
 
@@ -31,7 +35,10 @@ class GodotPlugin : KotlinCompilerPluginSupportPlugin {
     override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
 
-        val srcDirs = kotlinCompilation.allKotlinSourceSets.flatMap { it.kotlin.srcDirs }
+        val srcDirs = kotlinCompilation
+            .allKotlinSourceSets
+            .flatMap { it.kotlin.srcDirs }
+            .map { it.absolutePathFixedForWindows }
 
         return project.provider {
             listOf(
@@ -45,9 +52,9 @@ class GodotPlugin : KotlinCompilerPluginSupportPlugin {
                         mkdirs()
                     }.absolutePath
                 ),
-                FilesSubpluginOption(
+                SubpluginOption(
                     CompilerPluginConst.CommandLineOptionNames.sourcesDirPathOption,
-                    srcDirs
+                    srcDirs.joinToString(File.pathSeparator)
                 ),
                 SubpluginOption(
                     CompilerPluginConst.CommandLineOptionNames.entryDirPathOption,

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
@@ -2,10 +2,17 @@ package godot.gradle
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import godot.entrygenerator.EntryGenerator
+import godot.gradle.util.absolutePathFixedForWindows
 import godot.gradle.util.mapOfNonNullValuesOf
 import godot.utils.GodotBuildProperties
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.creating
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.getting
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.named
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import java.io.File
 
@@ -123,7 +130,7 @@ fun Project.setupConfigurationsAndCompilations(jvm: KotlinJvmProjectExtension) {
                             kotlinSourceSet
                                 .kotlin
                                 .srcDirs
-                                .map { srcDir -> srcDir.absolutePath }
+                                .map { it.absolutePathFixedForWindows }
                         },
                     project.buildDir.resolve("godot-entry").absolutePath
                 )

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/util/fileExt.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/util/fileExt.kt
@@ -1,0 +1,7 @@
+package godot.gradle.util
+
+import java.io.File
+
+val File.absolutePathFixedForWindows: String
+    get() = absolutePath.removeSuffix(";C") // don't know what this is but it's here on windows on kotlin sources dir's path and it has to be removed for the files to be found...
+


### PR DESCRIPTION
This fixes incremental builds on windows.
They were broken as the code i was using to get all the source code from a project could not find any source code files as all absolute paths of kotlin source code directories of windows end in `;C`. But only kotlin source directories. All other directories including java source directories not. WTF????
Anyways. By removing that suffix from the absolute path's, the files can be found and the incremental builds also work for windows.

Edit:
Found another problem, the cleanup as deleting to many files because of wrong file separator usage. Fixed that as well.