### PR TITLE
Add additional checks in intellij plugin and compiler plugin

### DIFF
--- a/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
+++ b/kt/entry-generation/godot-annotation-processor/src/main/kotlin/godot/annotation/processor/GodotAnnotationProcessor.kt
@@ -129,7 +129,8 @@ class GodotAnnotationProcessor(
             classes,
             properties,
             functions,
-            signals
+            signals,
+            srcDirs.map { it.absolutePath }
         )
         EntryGenerator.generateServiceFile(serviceFileOutputDir)
     }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -5,6 +5,10 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
 import godot.intellij.plugin.data.cache.classname.RegisteredClassNameCacheProvider
+import godot.intellij.plugin.data.model.REGISTER_CLASS_ANNOTATION
+import godot.intellij.plugin.data.model.REGISTER_FUNCTION_ANNOTATION
+import godot.intellij.plugin.data.model.REGISTER_PROPERTY_ANNOTATION
+import godot.intellij.plugin.data.model.REGISTER_SIGNAL_ANNOTATION
 import godot.intellij.plugin.extension.anyFunctionHasAnnotation
 import godot.intellij.plugin.extension.anyPropertyHasAnnotation
 import godot.intellij.plugin.extension.getRegisteredClassName
@@ -12,9 +16,13 @@ import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.ClassAlreadyRegisteredQuickFix
 import godot.intellij.plugin.quickfix.ClassNotRegisteredQuickFix
 import org.jetbrains.kotlin.idea.util.findAnnotation
+import org.jetbrains.kotlin.idea.util.module
+import org.jetbrains.kotlin.idea.util.sourceRoots
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.allConstructors
+import java.io.File
 
 private const val MAX_CONSTRUCTOR_ARGS = 5
 
@@ -22,33 +30,52 @@ class RegisterClassAnnotator : Annotator {
     private val classNotRegisteredQuickFix by lazy { ClassNotRegisteredQuickFix() }
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        if (element is KtClass) {
-            if (element.findAnnotation(FqName("godot.annotation.RegisterClass")) == null) {
-                val errorLocation = element.nameIdentifier ?: element.navigationElement
-                if (element.anyPropertyHasAnnotation("godot.annotation.RegisterProperty")) {
-                    holder.registerProblem(
-                        GodotPluginBundle.message("problem.class.notRegistered.properties"),
-                        errorLocation,
-                        classNotRegisteredQuickFix
-                    )
+        when (element) {
+            is KtClass -> {
+                if (element.findAnnotation(FqName(REGISTER_CLASS_ANNOTATION)) == null) {
+                    val errorLocation = element.nameIdentifier ?: element.navigationElement
+                    if (element.anyPropertyHasAnnotation(REGISTER_PROPERTY_ANNOTATION)) {
+                        holder.registerProblem(
+                            GodotPluginBundle.message("problem.class.notRegistered.properties"),
+                            errorLocation,
+                            classNotRegisteredQuickFix
+                        )
+                    }
+                    if (element.anyPropertyHasAnnotation(REGISTER_SIGNAL_ANNOTATION)) {
+                        holder.registerProblem(
+                            GodotPluginBundle.message("problem.class.notRegistered.signals"),
+                            errorLocation,
+                            classNotRegisteredQuickFix
+                        )
+                    }
+                    if (element.anyFunctionHasAnnotation(REGISTER_FUNCTION_ANNOTATION)) {
+                        holder.registerProblem(
+                            GodotPluginBundle.message("problem.class.notRegistered.functions"),
+                            errorLocation,
+                            classNotRegisteredQuickFix
+                        )
+                    }
+                } else {
+                    checkConstructorParameterCount(element, holder)
+                    checkRegisteredClassName(element, holder)
+                    checkOneRegisteredClassPerFile(element, holder)
+                    checkFileName(element, holder)
                 }
-                if (element.anyPropertyHasAnnotation("godot.annotation.RegisterSignal")) {
-                    holder.registerProblem(
-                        GodotPluginBundle.message("problem.class.notRegistered.signals"),
-                        errorLocation,
-                        classNotRegisteredQuickFix
-                    )
+            }
+            is KtPackageDirective -> {
+                val isAnyContainingClassRegistered = element
+                    .containingKtFile
+                    .classes
+                    .any { ktClass ->
+                        ktClass
+                            .annotations
+                            .mapNotNull { it.qualifiedName }
+                            .any { annotationFqName -> annotationFqName == REGISTER_CLASS_ANNOTATION }
+                    }
+
+                if (isAnyContainingClassRegistered) {
+                    checkPackagePath(element, holder)
                 }
-                if (element.anyFunctionHasAnnotation("godot.annotation.RegisterFunction")) {
-                    holder.registerProblem(
-                        GodotPluginBundle.message("problem.class.notRegistered.functions"),
-                        errorLocation,
-                        classNotRegisteredQuickFix
-                    )
-                }
-            } else {
-                checkConstructorParameterCount(element, holder)
-                checkRegisteredClassName(element, holder)
             }
         }
     }
@@ -58,7 +85,8 @@ class RegisterClassAnnotator : Annotator {
             if (ktConstructor.valueParameters.size > MAX_CONSTRUCTOR_ARGS) {
                 holder.registerProblem(
                     GodotPluginBundle.message("problem.class.constructor.toManyParams"),
-                    ktConstructor.valueParameterList?.psiOrParent ?: ktConstructor.nameIdentifier ?: ktConstructor.navigationElement
+                    ktConstructor.valueParameterList?.psiOrParent ?: ktConstructor.nameIdentifier
+                    ?: ktConstructor.navigationElement
                 )
             }
         }
@@ -71,7 +99,7 @@ class RegisterClassAnnotator : Annotator {
             .map { container -> container.fqName }
 
         if (fqNames.size > 1 || (fqNames.size == 1 && !fqNames.contains(fqName))) {
-            val registerClassAnnotation = ktClass.findAnnotation(FqName("godot.annotation.RegisterClass"))
+            val registerClassAnnotation = ktClass.findAnnotation(FqName(REGISTER_CLASS_ANNOTATION))
             val psiElement = if (registerClassAnnotation == null) {
                 ktClass.nameIdentifier ?: ktClass.navigationElement
             } else {
@@ -88,6 +116,54 @@ class RegisterClassAnnotator : Annotator {
                 GodotPluginBundle.message("problem.class.nameAlreadyRegistered"),
                 psiElement,
                 ClassAlreadyRegisteredQuickFix(registeredName)
+            )
+        }
+    }
+
+    private fun checkOneRegisteredClassPerFile(ktClass: KtClass, holder: AnnotationHolder) {
+        val containingFileContainsMoreRegisteredClasses = ktClass
+            .containingKtFile
+            .classes
+            .filter { ktClass ->
+                ktClass
+                    .annotations
+                    .firstOrNull { annotation -> annotation.qualifiedName == REGISTER_CLASS_ANNOTATION } != null
+            }
+            .size > 1
+
+        if (containingFileContainsMoreRegisteredClasses) {
+            holder.registerProblem(
+                GodotPluginBundle.message("problem.class.moreThanOneRegisteredClass"),
+                ktClass.identifyingElement ?: ktClass
+            )
+        }
+    }
+
+    private fun checkFileName(ktClass: KtClass, holder: AnnotationHolder) {
+        if (ktClass.containingKtFile.virtualFile.name.removeSuffix(".kt") != ktClass.name) {
+            holder.registerProblem(
+                GodotPluginBundle.message("problem.class.wrongFileName"),
+                ktClass.identifyingElement ?: ktClass
+                // no quick fix needed -> already one present from the kotlin plugin
+            )
+        }
+    }
+
+    private fun checkPackagePath(ktPackageDirective: KtPackageDirective, holder: AnnotationHolder) {
+        var containingFilePath = ktPackageDirective.containingKtFile.virtualFile.path
+        val srcDirs = ktPackageDirective.module?.sourceRoots?.map { it.path } ?: return
+        srcDirs.forEach { srcDir ->
+            containingFilePath = containingFilePath.removePrefix(srcDir)
+        }
+        containingFilePath =
+            containingFilePath.substringBeforeLast(File.separator).removePrefix(File.separator).removeSuffix(".kt")
+        val packagePath = ktPackageDirective.fqName.asString().replace(".", File.separator)
+
+        if (packagePath != containingFilePath) {
+            holder.registerProblem(
+                GodotPluginBundle.message("problem.class.wrongPackagePath"),
+                ktPackageDirective
+                // no quick fix needed -> already one present from the kotlin plugin
             )
         }
     }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -85,8 +85,11 @@ class RegisterClassAnnotator : Annotator {
             if (ktConstructor.valueParameters.size > MAX_CONSTRUCTOR_ARGS) {
                 holder.registerProblem(
                     GodotPluginBundle.message("problem.class.constructor.toManyParams"),
-                    ktConstructor.valueParameterList?.psiOrParent ?: ktConstructor.nameIdentifier
-                    ?: ktConstructor.navigationElement
+                    ktConstructor
+                        .valueParameterList
+                        ?.psiOrParent
+                        ?: ktConstructor.nameIdentifier
+                        ?: ktConstructor.navigationElement
                 )
             }
         }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/function/RegisterFunctionAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/function/RegisterFunctionAnnotator.kt
@@ -4,6 +4,8 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_CLASS_ANNOTATION
+import godot.intellij.plugin.data.model.REGISTER_FUNCTION_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.NotificationFunctionNotRegisteredQuickFix
 import org.jetbrains.kotlin.idea.util.findAnnotation
@@ -17,9 +19,9 @@ class RegisterFunctionAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (element is KtNamedFunction) {
             if (
-                element.containingClass()?.findAnnotation(FqName("godot.annotation.RegisterClass")) != null &&
+                element.containingClass()?.findAnnotation(FqName(REGISTER_CLASS_ANNOTATION)) != null &&
                 notificationFunctions.contains(element.name) &&
-                element.findAnnotation(FqName("godot.annotation.RegisterFunction")) == null
+                element.findAnnotation(FqName(REGISTER_FUNCTION_ANNOTATION)) == null
             ) {
                 holder.registerProblem(
                     GodotPluginBundle.message("problem.function.notificationFunctionNotRegistered"),

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/PropertyHintAnnotationChecker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/PropertyHintAnnotationChecker.kt
@@ -2,6 +2,7 @@ package godot.intellij.plugin.annotator.property
 
 import com.intellij.lang.annotation.AnnotationHolder
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_PROPERTY_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import org.jetbrains.kotlin.idea.refactoring.fqName.fqName
 import org.jetbrains.kotlin.idea.util.findAnnotation
@@ -12,11 +13,7 @@ import org.jetbrains.kotlin.nj2k.postProcessing.type
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.types.typeUtil.isDouble
-import org.jetbrains.kotlin.types.typeUtil.isEnum
-import org.jetbrains.kotlin.types.typeUtil.isFloat
-import org.jetbrains.kotlin.types.typeUtil.isInt
-import org.jetbrains.kotlin.types.typeUtil.isLong
+import org.jetbrains.kotlin.types.typeUtil.*
 
 private const val MAX_ENUM_ENTRIES_FOR_ENUM_FLAGS = 32
 
@@ -198,7 +195,7 @@ class PropertyHintAnnotationChecker {
     }
 
     private fun checkForRegistrationAnnotation(ktProperty: KtProperty, holder: AnnotationHolder) {
-        if (ktProperty.findAnnotation(FqName("godot.annotation.RegisterProperty")) == null) {
+        if (ktProperty.findAnnotation(FqName(REGISTER_PROPERTY_ANNOTATION)) == null) {
             holder.registerProblem(
                 GodotPluginBundle.message("problem.property.hint.notRegistered"),
                 ktProperty.nameIdentifier ?: ktProperty.navigationElement

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/PropertyHintAnnotationChecker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/PropertyHintAnnotationChecker.kt
@@ -13,7 +13,11 @@ import org.jetbrains.kotlin.nj2k.postProcessing.type
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.types.typeUtil.*
+import org.jetbrains.kotlin.types.typeUtil.isDouble
+import org.jetbrains.kotlin.types.typeUtil.isEnum
+import org.jetbrains.kotlin.types.typeUtil.isFloat
+import org.jetbrains.kotlin.types.typeUtil.isInt
+import org.jetbrains.kotlin.types.typeUtil.isLong
 
 private const val MAX_ENUM_ENTRIES_FOR_ENUM_FLAGS = 32
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/RegisterPropertiesAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/RegisterPropertiesAnnotator.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_PROPERTY_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.RegisterPropertyMutabilityQuickFix
 import org.jetbrains.kotlin.idea.intentions.loopToCallChain.isConstant
@@ -20,7 +21,7 @@ class RegisterPropertiesAnnotator : Annotator {
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (element is KtProperty) {
-            if (element.findAnnotation(FqName("godot.annotation.RegisterProperty")) != null) {
+            if (element.findAnnotation(FqName(REGISTER_PROPERTY_ANNOTATION)) != null) {
                 checkMutability(element, holder)
                 checkRegisteredType(element, holder)
                 checkIfDefaultValueIsConstant(element, holder)

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/signal/RegisterSignalAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/signal/RegisterSignalAnnotator.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_SIGNAL_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.RegisterSignalInitializerQuickFix
 import godot.intellij.plugin.quickfix.RegisterSignalMutabilityQuickFix
@@ -19,7 +20,7 @@ class RegisterSignalAnnotator : Annotator {
     private val useDelegateQuickFix by lazy { RegisterSignalInitializerQuickFix() }
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
-        if (element is KtProperty && element.findAnnotation(FqName("godot.annotation.RegisterSignal")) != null) {
+        if (element is KtProperty && element.findAnnotation(FqName(REGISTER_SIGNAL_ANNOTATION)) != null) {
             checkMutability(element, holder)
             checkRegisteredType(element, holder)
         }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/model/annotations.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/model/annotations.kt
@@ -1,0 +1,6 @@
+package godot.intellij.plugin.data.model
+
+const val REGISTER_CLASS_ANNOTATION = "godot.annotation.RegisterClass"
+const val REGISTER_FUNCTION_ANNOTATION = "godot.annotation.RegisterFunction"
+const val REGISTER_PROPERTY_ANNOTATION = "godot.annotation.RegisterProperty"
+const val REGISTER_SIGNAL_ANNOTATION = "godot.annotation.RegisterSignal"

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/ClassNotRegisteredQuickFix.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/ClassNotRegisteredQuickFix.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_CLASS_ANNOTATION
 import org.jetbrains.kotlin.idea.util.addAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
@@ -21,6 +22,6 @@ class ClassNotRegisteredQuickFix : LocalQuickFix {
 
         ktClass
             .let { it as? KtModifierListOwner }
-            ?.addAnnotation(FqName("godot.annotation.RegisterClass"))
+            ?.addAnnotation(FqName(REGISTER_CLASS_ANNOTATION))
     }
 }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/NotificationFunctionNotRegisteredQuickFix.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/NotificationFunctionNotRegisteredQuickFix.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_FUNCTION_ANNOTATION
 import org.jetbrains.kotlin.idea.util.addAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -13,6 +14,6 @@ class NotificationFunctionNotRegisteredQuickFix : LocalQuickFix {
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
         val ktNamedFunction = descriptor.psiElement as KtNamedFunction
-        ktNamedFunction.addAnnotation(FqName("godot.annotation.RegisterFunction"))
+        ktNamedFunction.addAnnotation(FqName(REGISTER_FUNCTION_ANNOTATION))
     }
 }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/RegisterSignalInitializerQuickFix.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/RegisterSignalInitializerQuickFix.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.openapi.project.Project
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.data.model.REGISTER_SIGNAL_ANNOTATION
 import org.jetbrains.kotlin.idea.util.addAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtModifierListOwner
@@ -23,7 +24,7 @@ class RegisterSignalInitializerQuickFix : LocalQuickFix {
         val property = propertyPsi.replace(newProperty)
         property.add(delegate)
 
-        (property as KtModifierListOwner).addAnnotation(FqName("godot.annotation.RegisterSignal"))
+        (property as KtModifierListOwner).addAnnotation(FqName(REGISTER_SIGNAL_ANNOTATION))
 
         val baseImportPath = "godot.signals"
         val importDirective = factory.createImportDirective(ImportPath(FqName("$baseImportPath.signal"), false))

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
@@ -4,6 +4,9 @@ problem.class.notRegistered.functions=This class contains registered functions b
 problem.class.notRegistered.signals=This class contains registered signals but is not registered
 problem.class.constructor.toManyParams=Godot cannot handle constructors for registered classes with more than 5 parameters. Reduce your parameter count
 problem.class.nameAlreadyRegistered=Class name already registered
+problem.class.moreThanOneRegisteredClass=More than one registered class in the containing file
+problem.class.wrongFileName=File name has to match class name
+problem.class.wrongPackagePath=Package path has to match actual directory path
 problem.function.notificationFunctionNotRegistered=Overridden notification function which is not registered will not be called by Godot.\n\
 Using notification functions for other purposes than to be called from Godot is considered a bad practise.\n\
 Either register it or move your logic to a custom function you defined


### PR DESCRIPTION
Currently the class registration has some important limitations:
- Only one class per file can be registered
- The file name has to match the class name
- The package path has to match the folder structure

This PR implements additional checks for both compiler plugin (to let the compilation fail if one of the above mentioned is not fulfilled) and for the intellij plugin (to provide error messages in the IDE).

Depends on: https://github.com/utopia-rise/godot-kotlin-entry-generator/pull/13