### PR TITLE
Implement script move refactoring support for scene files

### DIFF
--- a/kt/plugins/godot-intellij-plugin/detekt-config.yml
+++ b/kt/plugins/godot-intellij-plugin/detekt-config.yml
@@ -39,5 +39,5 @@ complexity:
   LongMethod:
     excludes: [
         '**/godot/intellij/plugin/linemarker/SignalConnectionLineMarker.kt',
-        '**/godot/intellij/plugin/data/cache/SignalConnectionCache.kt',
+        '**/godot/intellij/plugin/data/cache/signalconnection/SignalConnectionCache.kt',
     ]

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -4,7 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
-import godot.intellij.plugin.data.cache.RegisteredClassNameCacheProvider
+import godot.intellij.plugin.data.cache.classname.RegisteredClassNameCacheProvider
 import godot.intellij.plugin.extension.anyFunctionHasAnnotation
 import godot.intellij.plugin.extension.anyPropertyHasAnnotation
 import godot.intellij.plugin.extension.getRegisteredClassName

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/classname/RegisteredClassNameCache.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/classname/RegisteredClassNameCache.kt
@@ -1,4 +1,4 @@
-package godot.intellij.plugin.data.cache
+package godot.intellij.plugin.data.cache.classname
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/classname/RegisteredClassNameCacheProvider.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/classname/RegisteredClassNameCacheProvider.kt
@@ -1,4 +1,4 @@
-package godot.intellij.plugin.data.cache
+package godot.intellij.plugin.data.cache.classname
 
 import com.intellij.openapi.project.Project
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/signalconnection/SignalConnectionCache.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/signalconnection/SignalConnectionCache.kt
@@ -1,4 +1,4 @@
-package godot.intellij.plugin.data.cache
+package godot.intellij.plugin.data.cache.signalconnection
 
 import com.intellij.openapi.project.Project
 import com.utopiarise.serialization.godot.model.SignalConnection

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/signalconnection/SignalConnectionCacheProvider.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/data/cache/signalconnection/SignalConnectionCacheProvider.kt
@@ -1,4 +1,4 @@
-package godot.intellij.plugin.data.cache
+package godot.intellij.plugin.data.cache.signalconnection
 
 import com.intellij.openapi.project.Project
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/linemarker/SignalConnectionLineMarker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/linemarker/SignalConnectionLineMarker.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.openapi.util.IconLoader
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
-import godot.intellij.plugin.data.cache.SignalConnectionCacheProvider
+import godot.intellij.plugin.data.cache.signalconnection.SignalConnectionCacheProvider
 import godot.intellij.plugin.extension.isSignal
 import godot.intellij.plugin.ui.dialog.IncomingSignalConnectionsDialog
 import godot.intellij.plugin.ui.dialog.OutgoingSignalConnectionsDialog

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/listener/GodotSceneBulkFileListener.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/listener/GodotSceneBulkFileListener.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
 import com.utopiarise.serialization.godot.scene.sceneFromTscn
 import godot.intellij.plugin.ProjectDisposable
-import godot.intellij.plugin.data.cache.SignalConnectionCacheProvider
+import godot.intellij.plugin.data.cache.signalconnection.SignalConnectionCacheProvider
 
 class GodotSceneBulkFileListener(private val project: Project) : BulkFileListener, ProjectDisposable {
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/ClassAlreadyRegisteredQuickFix.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/ClassAlreadyRegisteredQuickFix.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import godot.intellij.plugin.GodotPluginBundle
-import godot.intellij.plugin.data.cache.RegisteredClassNameCacheProvider
+import godot.intellij.plugin.data.cache.classname.RegisteredClassNameCacheProvider
 import godot.intellij.plugin.data.model.RegisteredClassDataContainer
 import org.jetbrains.kotlin.idea.core.util.getLineNumber
 import org.jetbrains.kotlin.idea.core.util.toPsiFile

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/refactor/SceneAction.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/refactor/SceneAction.kt
@@ -1,0 +1,39 @@
+package godot.intellij.plugin.refactor
+
+import com.intellij.openapi.project.Project
+import java.io.File
+
+object SceneAction {
+
+    /**
+     * Replaces old script paths in scene files with new script paths where possible
+     */
+    fun scriptMoved(project: Project, oldPath: String, newPath: String, fqNames: List<String>) {
+        val resPath = project.basePath ?: return
+        val oldPathResBased = oldPath.removePrefix(resPath).removePrefix(File.separator).replace(File.separator, "/")
+        val newPathResBased = newPath.removePrefix(resPath).removePrefix(File.separator).replace(File.separator, "/")
+
+        File(resPath)
+            .walkTopDown()
+            .filter { it.isFile && it.exists() && it.extension == "tscn" }
+            .forEach { sceneFile ->
+                // if this should become a memory problem on large scene files,
+                // replace it with a buffered read/write line by line to a new file
+                // and replace the old file with the new one when done writing
+                val sceneContent = sceneFile.readText()
+                var newSceneContent = sceneContent
+                fqNames.forEach { fqName ->
+                    val className = fqName.substringAfterLast(".")
+                    val oldResPath = "res://$oldPathResBased/$className.kt"
+                    val newResPath = "res://$newPathResBased/$className.kt"
+
+                    if (sceneContent.contains(oldResPath)) {
+                        newSceneContent = sceneContent.replace(oldResPath, newResPath)
+                    }
+                }
+                if (newSceneContent != sceneContent) {
+                    sceneFile.writeText(newSceneContent)
+                }
+            }
+    }
+}


### PR DESCRIPTION
This implements support for script moving from within intellij.

When a registered class is moved inside Intellij all occurrences of that class in all scene files (`tscn` only) are now updated as well.