### PR TITLE
Implement support for custom srcDirs

### DIFF
--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -11,3 +11,8 @@ repositories {
 dependencies {
     implementation("joda-time:joda-time:2.10.6") //external dependency to test dependency inclusion in dummyCompilation
 }
+
+
+kotlin.sourceSets.main {
+    kotlin.srcDirs("scripts")
+}

--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Node",
+"class": "ScriptInOtherSourceDir",
+"language": "Kotlin",
+"path": "res://scripts/ScriptInOtherSourceDir.kt"
+}, {
 "base": "Spatial",
 "class": "godot_tests_Invocation",
 "language": "Kotlin",
@@ -30,6 +35,7 @@ _global_script_classes=[ {
 "path": "res://src/main/kotlin/godot/tests/subpackage/OtherScript.kt"
 } ]
 _global_script_class_icons={
+"ScriptInOtherSourceDir": "",
 "godot_tests_Invocation": "",
 "godot_tests_inheritance_ClassInheritanceChild": "",
 "godot_tests_inheritance_ClassInheritanceParent": "",

--- a/harness/tests/scripts/ScriptInOtherSourceDir.kt
+++ b/harness/tests/scripts/ScriptInOtherSourceDir.kt
@@ -1,0 +1,10 @@
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+
+@RegisterClass
+class ScriptInOtherSourceDir: Node() {
+
+    @RegisterFunction
+    fun greeting() = "HelloWorld"
+}

--- a/harness/tests/test/unit/test_custom_src_dir.gd
+++ b/harness/tests/test/unit/test_custom_src_dir.gd
@@ -1,0 +1,8 @@
+extends "res://addons/gut/test.gd"
+
+func test_call_script_in_custom_src_dir():
+	var spatial = Spatial.new()
+	var script = ScriptInOtherSourceDir.new()
+	spatial.add_child(script)
+	assert_eq(script.greeting(), "HelloWorld", "greeting should return \"HelloWorld\"")
+	spatial.free()

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -245,7 +245,6 @@ void GDKotlin::init() {
     jni::Jvm::init(args);
     LOG_INFO("Starting JVM ...")
     auto project_settings = ProjectSettings::get_singleton();
-    scripts_root = "res://src/main/kotlin/";
     String bootstrap_jar = OS::get_singleton()->get_executable_path().get_base_dir() + "/godot-bootstrap.jar";
     JVM_CRASH_COND_MSG(!FileAccess::exists(bootstrap_jar),
                    "No godot-bootstrap.jar found! This file needs to stay alongside the godot editor executable!")
@@ -394,6 +393,7 @@ void GDKotlin::unregister_classes(jni::Env& p_env, jni::JObjectArray p_classes) 
 
 KtClass* GDKotlin::find_class(const StringName& p_script_path) {
 #ifdef DEBUG_ENABLED
+    //FIXME: this crashes the editor when creating a kotlin script through the godot editor. Cause: this function gets called for the newly created script but of course it's not compiled yet as it was just added now...
     JVM_ERR_FAIL_COND_V_MSG(!classes.has(p_script_path), nullptr,
                    vformat("Failed to find class for path: %s", p_script_path));
 #endif

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -393,7 +393,7 @@ void GDKotlin::unregister_classes(jni::Env& p_env, jni::JObjectArray p_classes) 
 
 KtClass* GDKotlin::find_class(const StringName& p_script_path) {
 #ifdef DEBUG_ENABLED
-    //FIXME: this crashes the editor when creating a kotlin script through the godot editor. Cause: this function gets called for the newly created script but of course it's not compiled yet as it was just added now...
+    //FIXME: https://github.com/utopia-rise/godot-jvm/issues/76
     JVM_ERR_FAIL_COND_V_MSG(!classes.has(p_script_path), nullptr,
                    vformat("Failed to find class for path: %s", p_script_path));
 #endif

--- a/src/gd_kotlin.h
+++ b/src/gd_kotlin.h
@@ -23,7 +23,6 @@ private:
 
     Error split_jvm_debug_argument(const String& cmd_arg, String& result);
 public:
-    String scripts_root;
     TransferContext* transfer_context;
     Vector<StringName> engine_type_names;
     Vector<MethodBind*> engine_type_method;

--- a/src/kotlin_language.cpp
+++ b/src/kotlin_language.cpp
@@ -147,11 +147,11 @@ void KotlinLanguage::get_string_delimiters(List<String>* p_delimiters) const {
 
 Ref<Script> KotlinLanguage::get_template(const String& p_class_name, const String& p_base_class_name) const {
     String kotlinClassTemplate {
-        "package " GODOT_KOTLIN_PACKAGE "\n"
+        "package fixme\n"
         "\n"
         "import " GODOT_KOTLIN_PACKAGE ".%BASE%"
         "\n"
-        "class %CLASS% : %BASE% {\n"
+        "class %CLASS% : %BASE%() {\n"
         "\n"
         "    // Declare member variables here. Examples:\n"
         "    // val a = 2;\n"
@@ -163,7 +163,7 @@ Ref<Script> KotlinLanguage::get_template(const String& p_class_name, const Strin
         "    }\n"
         "\n"
         "    // Called every frame. 'delta' is the elapsed time since the previous frame.\n"
-        "    override fun _process(float delta) {\n"
+        "    override fun _process(delta: Double) {\n"
         "        \n"
         "    }\n"
         "}\n"
@@ -200,9 +200,6 @@ String KotlinLanguage::validate_path(const String& p_path) const {
     get_reserved_words(&keywords);
     if (keywords.find(p_path.get_file().get_basename())) {
         return TTR("Please don't use reserved keywords as file name.");
-    }
-    if (!p_path.begins_with(GDKotlin::get_instance().scripts_root)) {
-        return TTR("Kotlin classes must be placed at src/main/kotlin.");
     }
     return "";
 }


### PR DESCRIPTION
This replaces https://github.com/utopia-rise/godot-jvm/pull/58 as the changes on the master were to great to change the old PR and many things from it were not needed anymore.

This adds support for custom source dirs.

Not necessarily needed but the name registration fix of the entry gen should be merged first.
https://github.com/utopia-rise/godot-kotlin-entry-generator/pull/19