### PR TITLE
Pre-Alpha docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,8 @@ You also don't have to worry about any binding logic. Just write your game scrip
 
 ## Important notes
 
-This version of the binding is currently **WIP**! It cannot be used to build games yet.  
-For a more stable, yet much less performant binding using Kotlin Native instead of Kotlin on the JVM, visit [godot-kotlin](https://github.com/utopia-rise/godot-kotlin).  
-
-## Documentation
-
-Documentation will be added once the binding reaches the **Alpha** state.
+This version of the binding is currently **Pre-Alpha**!  
+For more information see [Pre-Alpha instructions](docs/src/doc/pre-alpha.md) in the docs.
 
 ## Developer discussion
 
@@ -37,7 +33,7 @@ Each Issue has a Maintainer that is the "supervisor" for the general topic the i
 
 2. In `godot/`, run the following command: `git submodule add git@github.com:utopia-rise/godot-jvm.git modules/kotlin_jvm`
 
-3. Pull submodules of our project (currently only the entry generator): 
+3. Pull submodules of our project: 
     - `cd modules/kotlin_jvm`
     - `git submodule update --init --recursive`
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,4 +10,7 @@
 * [Advanced]()
     * [Custom Src dirs](src/doc/advanced/custom-src-dirs.md)
     * [Commandline args](src/doc/advanced/commandline-args.md)
-* [API differences](src/doc/api-differences.m
+* [API differences](src/doc/api-differences.md)
+* [Versioning](src/doc/versioning.md)
+* [Supported platforms](src/doc/supported-platforms.md)
+* [Contribution](src/doc/contribution.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,7 +7,7 @@
     * [Properties](src/doc/user-guide/properties.md)
     * [Signals](src/doc/user-guide/signals.md)
     * [Functions](src/doc/user-guide/functions.md)
-* [API differences](src/doc/api-differences.md)
-* [Versioning](src/doc/versioning.md)
-* [Supported platforms](src/doc/supported-platforms.md)
-* [Contribution](src/doc/contribution.md)
+* [Advanced]()
+    * [Custom Src dirs](src/doc/advanced/custom-src-dirs.md)
+    * [Commandline args](src/doc/advanced/commandline-args.md)
+* [API differences](src/doc/api-differences.m

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ nav:
   - Advanced:
     - Custom Src dirs: advanced/custom-src-dirs.md
     - Commandline args: advanced/commandline-args.md
-  - API differences: api-differenc
+  - API differences: api-differences.md
   - Versioning: versioning.md
   - Supported platforms: supported-platforms.md
   - Contribution: contribution.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -38,3 +38,6 @@ nav:
     - Custom Src dirs: advanced/custom-src-dirs.md
     - Commandline args: advanced/commandline-args.md
   - API differences: api-differenc
+  - Versioning: versioning.md
+  - Supported platforms: supported-platforms.md
+  - Contribution: contribution.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -34,7 +34,7 @@ nav:
     - Properties: user-guide/properties.md
     - Signals: user-guide/signals.md
     - Functions: user-guide/functions.md
-  - API differences: api-differences.md
-  - Versioning: versioning.md
-  - Supported platforms: supported-platforms.md
-  - Contribution: contribution.md
+  - Advanced:
+    - Custom Src dirs: advanced/custom-src-dirs.md
+    - Commandline args: advanced/commandline-args.md
+  - API differences: api-differenc

--- a/docs/src/doc/advanced/commandline-args.md
+++ b/docs/src/doc/advanced/commandline-args.md
@@ -1,0 +1,12 @@
+The following command line args can be supplied to customize the behaviour or the Godot-Jvm binding:
+
+| arg | default value | description |
+| --- | --- | ---|
+| --jvm-debug-port | | Defines the port to which you can attach a remote debugger. **Note:** the module `jdk.jdwp.agent` is needed in the embedded JRE if you want to debug your application. If you need `jmx`, also the module `jdk.management.agent` is needed. |
+| --jvm-debug-address | | Defines which adresses are allowed for debugging |
+| --jvm-jmx-port | | Defines the jmx port. **Note:** the module `jdk.management.agent` is needed in the embedded JRE to be able to use jmx |
+| --jvm-gc-thread-period-millis | 500 | Define at which interval our GC (**not** the jvm GC) is running. |
+| --jvm-to-engine-shared-buffer-size | 20'000'000 | Buffer size in bytes which is used for value transfer between jvm and cpp. Setting applies for each thread. |
+| --jvm-force-gc | | If set the JVM GC is forced to run when our own GC runs. The interval is defined with `--jvm-gc-thread-period-millis` and defaults to 500ms |
+| --jvm-disable-gc | | Disables our GC. **Caution:** If you disable our GC you **will** have memory leaks as all Reference types and Native Types are not Garbage collected anymore.
+| --jvm-disable-closing-leaks-warning | | Disables the output of leaked instances when closing the application |

--- a/docs/src/doc/advanced/custom-src-dirs.md
+++ b/docs/src/doc/advanced/custom-src-dirs.md
@@ -1,0 +1,8 @@
+To be able to use custom source dirs, you just have to configure it for the `main` sourceSet in gradle:
+
+`build.gradle.kts`:
+```kotlin
+kotlin.sourceSets.main {
+    kotlin.srcDirs("scripts")
+}
+```

--- a/docs/src/doc/api-differences.md
+++ b/docs/src/doc/api-differences.md
@@ -12,59 +12,15 @@ Godot singletons are mapped as Kotlin objects.
 Physics2DServer.areaGetTransform(area)
 ```
 
-## Core types
-Godot's built-in types are passed by value (except for `Dictionary` and `VariantArray` - more on this later), so the following snippet won't work as expected.
-
-```kotlin
-val spatial = Spatial()
-spatial.rotation.y += 10f
-```
-
-You are actually mutating a copy of the `rotation` property, not a reference to it. To get the desired behaviour you have to re-assign the copy back. 
-
-```kotlin
-val rotation = spatial.rotation
-rotation.y += 10f
-spatial.rotation = rotation
-``` 
-
-This approach introduces a lot of boilerplate, so this module provides a concise way of achieving the same behaviour.
-
-```kotlin
-spatial.rotation {
-  y += 10f
-}
-```
-
-The snippet above is functionally equivalent to the previous one.
-
-## Collection types
-While `VariantArray` and `Dictionary` are passed by reference, the value returned by the retrieval methods (`VariantArray.get(...)` and `Dictionary.get(...)`) are not.
-
-```kotlin
-array.get(index).asVector3().y += 10f
-dictionary.get("foo").asVector3().y += 5f
-```
-
-To get the desired behaviour, you can re-assign the copy back or in a similar fashion as before, this module provides a better alternative.
-
-```kotlin
-array.get<Vector3>(index) {
-  y += 10f
-}
-
-dictionary.get<Vector3>(index) {
-  y += 5f
-}
-``` 
-
 ## Enums and constants
 Godot enums are mapped to Kotlin enums, the generated enum exposes a `value` property that represents the value in Godot. Constants in Godot classes that represent an enum value (such as `Node.PAUSE_MODE_INHERIT`) are not present in this module, please use the generated enum instead (`Node.PauseMode.INHERIT`).
 
 ## Signals and exposed methods
-In GDScript, signals can have any number of arguments, this is not possible in Kotlin as it is a statically typed language. At the moment, you can create signals and expose them to Godot with at most 10 parameters.
+In GDScript, signals can have any number of arguments, this is not possible in Kotlin as it is a statically typed language. At the moment, you can create signals and expose them to Godot with at most 10 parameters.  
 
-Additionally, signals are mapped to properties of type `Signal` and must start with a prefix `signal` (check [Signals](user-guide/signals.md) section for more details). The prefix is dropped during registration and converted to snake_case, so the signal `signalReverseChanged` is known in Godot as `reverse_changed`. This is done to avoid naming conflicts with other members of a class. There is no signal type in GDScript, signals are only referenced by name so they can have the same name as methods and/or properties in the same class. 
+Additionally, signals are mapped to properties of type `Signal` and must start with a prefix `signal` (check [Signals](user-guide/signals.md) section for more details). The prefix is dropped during registration and converted to snake_case, so the signal `signalReverseChanged` is known in Godot as `reverse_changed`. This is done to avoid naming conflicts with other members of a class. There is no signal type in GDScript, signals are only referenced by name so they can have the same name as methods and/or properties in the same class.  
+
+If you need more than 10 parameters, you can either use the not typesafe function `connect(signalAsString, targetObject, targetMethodAsString)` and the corresponding emit function or you can write your own typesafe extension functions like we did, to further increase the supported arg count. Keep in mind that you pass in the converted function and signal names (snake_case) to the above mentioned functions.  
 
 ## Renamed symbols
 To avoid confusion and conflict with Kotlin types, the following Godot symbols are renamed.

--- a/docs/src/doc/index.md
+++ b/docs/src/doc/index.md
@@ -7,3 +7,6 @@ An embedded JRE will be shipped with your application to ensure it runs on syste
 
 If you are new to this language module, it is recommended to read through the [Versioning](versioning.md) and the [Getting started](getting-started/gradle.md) sections first.
 Please also note the [API differences](api-differences.md) section which covers some important difference to the scripting and workflow compared to GDScript.
+
+# State
+This binding is currently in Pre-Alpha state. For more information see [Pre-Alpha instructions](pre-alpha.md)

--- a/docs/src/doc/pre-alpha.md
+++ b/docs/src/doc/pre-alpha.md
@@ -1,0 +1,71 @@
+**Please note:** This is a Pre-Alpha. It is by no means production ready. Please only use it if you want to help with the development by testing or if you want to have a sneak peak at what's coming. 
+At the moment the whole setup process is quite tedious, not simple and more geard towards users familiar with godot and gradle.   
+Expect breaking changes for every commit we publish.
+
+# Artefacts
+For the Pre-Alpha, no artefacts are deployed and we do not provide a pre built engine yet.  
+If you want to try the binding at it's current state, you will have to build the binding and the engine yourself. See the section [setup](#setup) and [build](#build).
+
+# Setup
+1. Clone godot repo with 3.2 branch. `git clone git@github.com:godotengine/godot.git -b 3.2 --recursive`
+2. In `godot/`, run the following command: `git submodule add git@github.com:utopia-rise/godot-jvm.git modules/kotlin_jvm`
+3. Pull the submodules of our project: 
+    - `cd modules/kotlin_jvm`
+    - `git submodule update --init --recursive`
+
+# Documentation
+The documentation is currently not deployed. Once you have set up the project (see [setup](#setup)), you can launch the documentation in a local webserver. Just run the `run.sh` script in the `docs` folder.
+
+## Requirements
+To run the documentation locally you need:
+
+- Phython 3 installed
+- `pip install mkdocs`
+- `pip install mkdocs-material`
+
+
+# Build
+1. Build the engine with our module: `scons -j$(nproc) platform=x11 # your platform`
+2. Build `godot-bootstrap.jar`
+    - navigate to `kt/godot-library`
+    - `./gradlew build`
+3. Copy `godot-bootstrap.jar`:
+    - `cp build/libs/godot-bootstrap.jar ../../../../bin`
+    - **Note:** this needs to be done each time you pull the latest changes from this project until we ship a pre-built engine. There this jar will be included.
+
+# Setup your project
+At this state it's higly recommended to just put you project in the `harness` folder so you can more or less copy the gradle configuration from our sample projects.
+
+Most important is the configuration inside the `settings.gradle.kts` file as it includes the necessary build includes as long as we don't provide published artefacts.
+
+Just copy the one from the `tests` project and change the project name.
+
+Once you have done that, and set up the rest of the gradle project, you can open your project in intellij and all godot-jvm dependencies should be built for you. The first build can take a while.
+
+# Run your project
+Just run the engine executable you built in the [build](#build) section. It is in the `bin` folder of the root godot folder.
+
+# Rebuilding
+When you create new classes, you need to rebuild your project for godot to see your new classes.  
+If you rebuild while the editor is open, it should automatically reload your classes.
+
+# Exporting
+We currently do not explicitly support exporting of your projects, but generally it works. You just need to manually place the `godot-bootstrap.jar` and the `main.jar` alongside the exported executable.
+
+# Intellij plugin
+We recommend you build and install our intellij plugin located in `kt/plugins/godot-intellij-plugin` as it provides many code insight features to verify your registration code.
+
+# What's not working:
+The items in this list are explicitly mentioned here as these will be implemented in future versions. Also consider the [Api differences](api-differences.md) section for general differences and limitations which will not be or cannot be adressed in the near forseable future or ever.
+
+- Only default constructors are supported (no args)
+- No networking functionality (Rpc annotations do exist but they do not work yet)
+- No tool mode (you can set it already in the `@RegisterClass` annotation but it has no effect yet)
+- No plugin support -> You cannot use Godot-Jvm to write plugins and addons yet
+- No export support (but as mentioned in the [export](#export) section, it is generally already possible)
+- Only desktop OS are supported for now (Linux, MacOS, Windows)
+
+# Bug reporting and Questions
+If you find bugs, please report an [issue on github](https://github.com/utopia-rise/godot-jvm/issues). But check for duplicates first.  
+If you have questions or need help, you can ask on [discord](https://discord.gg/qSU2EQs) in the channels `questions` and `help` respectively.  
+If you don't have discord or don't want to use it, make a issue on github.


### PR DESCRIPTION
This adds more documentation geared towards the pre-alpha "release".
~~Please look again through the `Api-Differences` page as i don't think it is correct (regarding the value by copy vs value by reference). I would change it in this PR if incorrect.~~ fixed