### PR TITLE
Only load engine types once

### DIFF
--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -24,6 +24,7 @@ class Bootstrap {
     private lateinit var serviceLoader: ServiceLoader<Entry>
     private var executor: ScheduledExecutorService? = null
     private var watchService: WatchService? = null
+    private var engineTypesRegistered: Boolean = false
 
     fun init(isEditor: Boolean, projectDir: String) {
         val libsDir = Paths.get(projectDir, "build/libs")
@@ -96,13 +97,17 @@ class Bootstrap {
         if (entry.isPresent) {
             with(entry.get()) {
                 val context = Entry.Context(registry!!)
-                context.initEngineTypes()
-                registerManagedEngineTypes(
-                    TypeManager.engineTypeNames.toTypedArray(),
-                    TypeManager.engineSingletonsNames.toTypedArray(),
-                    TypeManager.engineTypeMethod.map { it.second }.toTypedArray(),
-                    TypeManager.engineTypeMethod.map { it.first }.toTypedArray()
-                )
+
+                if (!engineTypesRegistered) {
+                    context.initEngineTypes()
+                    registerManagedEngineTypes(
+                        TypeManager.engineTypeNames.toTypedArray(),
+                        TypeManager.engineSingletonsNames.toTypedArray(),
+                        TypeManager.engineTypeMethod.map { it.second }.toTypedArray(),
+                        TypeManager.engineTypeMethod.map { it.first }.toTypedArray()
+                    )
+                    engineTypesRegistered = true
+                }
 
                 context.init()
             }


### PR DESCRIPTION
This resolves #67 

Before we were loading all engine types on each rebuild while the editor was open. This is not necessary as they will never change in the time the editor is open.
This only loads them once for the runtime of an application.