### PR TITLE
Fix some extension methods

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -272,7 +272,6 @@ class Invocation : Spatial() {
         name = "TestName"
         println("Name is: $name")
         name = formerName
-
         val test = DateTime.now() //external dependency to test dependency inclusion in dummyCompilation
 
         signalNoParam.connect(invocation, invocation::hookNoParam)

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -272,6 +272,7 @@ class Invocation : Spatial() {
         name = "TestName"
         println("Name is: $name")
         name = formerName
+
         val test = DateTime.now() //external dependency to test dependency inclusion in dummyCompilation
 
         signalNoParam.connect(invocation, invocation::hookNoParam)

--- a/kt/godot-library/src/main/kotlin/godot/extensions.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions.kt
@@ -7,10 +7,10 @@ import godot.util.camelToSnakeCase
 import kotlin.reflect.KFunction
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> Node.getNode(path: String) = getNode(NodePath(path)) as T
+inline fun <T : Node?> Node.getNode(path: String) = getNode(NodePath(path)) as T
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> Node.getNode(nodePath: NodePath) = getNode(nodePath) as T
+inline fun <T : Node?> Node.getNode(nodePath: NodePath) = getNode(nodePath) as T
 
 /**
  * **Note:** The function name is converted to snake_case

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Object.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Object.kt
@@ -59,9 +59,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0> Signal1<A0>.emit(a0: A0) {
@@ -73,9 +73,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1> Signal2<A0, A1>.emit(a0: A0, a1: A1) {
@@ -87,9 +87,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2> Signal3<A0, A1, A2>.emit(
@@ -109,9 +109,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3> Signal4<A0, A1, A2, A3>.emit(
@@ -133,9 +133,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4> Signal5<A0, A1, A2, A3, A4>.emit(
@@ -159,9 +159,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4, A5> Signal6<A0, A1, A2, A3, A4, A5>.emit(
@@ -187,9 +187,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4, A5, A6> Signal7<A0, A1, A2, A3, A4, A5, A6>.emit(
@@ -217,9 +217,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4, A5, A6, A7> Signal8<A0, A1, A2, A3, A4, A5, A6, A7>.emit(
@@ -249,9 +249,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4, A5, A6, A7, A8> Signal9<A0, A1, A2, A3, A4, A5, A6, A7, A8>.emit(
@@ -283,9 +283,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   fun <A0, A1, A2, A3, A4, A5, A6, A7, A8, A9> Signal10<A0, A1, A2, A3, A4, A5, A6, A7, A8,
@@ -320,9 +320,9 @@ open class Object : KtObject() {
     method: K,
     binds: VariantArray<Any?>? = null,
     flags: Long = 0
-  ) {
+  ): GodotError {
     val methodName = (method as KCallable<*>).name.camelToSnakeCase()
-    connect(target, methodName, binds, flags)
+    return connect(target, methodName, binds, flags)
   }
 
   override fun __new(): VoidPtr = TransferContext.invokeConstructor(ENGINECLASS_OBJECT)

--- a/kt/godot-library/src/main/kotlin/godot/signals/Signals.kt
+++ b/kt/godot-library/src/main/kotlin/godot/signals/Signals.kt
@@ -20,9 +20,7 @@ open class Signal(
         method: String,
         binds: VariantArray<Any?>?,
         flags: Long
-    ) {
-        instance.connect(name, target, method, binds ?: VariantArray(), flags)
-    }
+    ) = instance.connect(name, target, method, binds ?: VariantArray(), flags)
 }
 
 class Signal0(instance: Object, name: String) : Signal(instance, name) {


### PR DESCRIPTION
Depends on https://github.com/utopia-rise/godot-kotlin-api-generator/pull/3 and fixes the following extension methods:

- `getNode<T>` now also allows nullable types
- `Signal<T>.connect` now correctly returns `GodotError`