### PR TITLE
Allow to choose were JVM dependencies are located

### DIFF
--- a/cpp/godot-jvm.cpp
+++ b/cpp/godot-jvm.cpp
@@ -287,6 +287,28 @@ String GodotJvm::copy_new_file_to_user_dir(const String& file_name) {
     return file_user_path;
 }
 
+void GodotJvm::copy_external_jars_to_user_dir() {
+    String source_directory {String(RES_DIRECTORY) + EXTERNAL_JARS_DIRECTORY};
+    Ref<DirAccess> source {DirAccess::open(source_directory)};
+    if (source.is_null()) { return; }
+
+    Ref<DirAccess> destination {DirAccess::open(USER_DIRECTORY)};
+    destination->make_dir_recursive(EXTERNAL_JARS_DIRECTORY);
+
+    if (source->list_dir_begin() != OK) { return; }
+    for (String entry = source->get_next(); !entry.is_empty(); entry = source->get_next()) {
+        if (source->current_is_dir() || entry.get_extension() != "jar") { continue; }
+
+        String source_file {source_directory.path_join(entry)};
+        String destination_file {String(EXTERNAL_JARS_DIRECTORY).path_join(entry)};
+        if (!FileAccess::file_exists(String(USER_DIRECTORY) + destination_file) ||
+            FileAccess::get_md5(String(USER_DIRECTORY) + destination_file) != FileAccess::get_md5(source_file)) {
+            destination->copy(source_file, destination_file);
+        }
+    }
+    source->list_dir_end();
+}
+
 #endif
 
 bool GodotJvm::load_bootstrap() {
@@ -374,6 +396,7 @@ bool GodotJvm::load_user_code() {
         String user_code_path {String(RES_DIRECTORY).path_join(USER_CODE_FILE)};
 #else
         String user_code_path {copy_new_file_to_user_dir(USER_CODE_FILE)};
+        copy_external_jars_to_user_dir();
 #endif
 
         if (!FileAccess::file_exists(user_code_path)) {

--- a/cpp/godot_jvm.h
+++ b/cpp/godot_jvm.h
@@ -46,6 +46,7 @@ namespace godot {
 
 #ifndef TOOLS_ENABLED
         static String copy_new_file_to_user_dir(const String& file_name);
+        static void copy_external_jars_to_user_dir();
 #endif
 
 #ifdef DYNAMIC_JVM

--- a/cpp/paths.h
+++ b/cpp/paths.h
@@ -12,6 +12,7 @@ static constexpr const char* JVM_CONFIGURATION_PATH {"res://godot_jvm_configurat
 
 static constexpr const char* DESKTOP_BOOTSTRAP_FILE {JVM_DIRECTORY "godot-bootstrap.jar"};
 static constexpr const char* DESKTOP_USER_CODE_FILE {JVM_DIRECTORY "main.jar"};
+static constexpr const char* EXTERNAL_JARS_DIRECTORY {JVM_DIRECTORY "external/"};
 
 static constexpr const char* LINUX_GRAAL_NATIVE_IMAGE_FILE {JVM_DIRECTORY "usercode.so"};
 static constexpr const char* LINUX_EMBEDDED_JRE_ARM_DIRECTORY {JVM_DIRECTORY "jre-arm64-linux"};

--- a/docs/src/doc/contribute/how-it-works/artifacts.md
+++ b/docs/src/doc/contribute/how-it-works/artifacts.md
@@ -40,15 +40,38 @@ during export. You never use it directly, and it is not added as a dependency an
 
 ### Overview
 
-The `main.jar` is built when you build your code. It is a shadow JAR containing only your compiled
-code and the generated registrar — `packageMainJarTask` explicitly clears its dependency
-configurations, so none of your declared dependencies end up in it. Those dependencies are instead
-bundled into `godot-bootstrap.jar`.
+The `main.jar` is built when you build your code. It is a shadow JAR containing your compiled code,
+the generated registrar, and dependencies declared with `godotMain`. Ordinary dependencies are
+instead bundled into `godot-bootstrap.jar`.
 
 ### Usage
 
 This JAR is bundled together with the game executable during export and executed through the `godot-bootstrap` during
 runtime. It is nowhere else used.
+
+## Dependency placement
+
+By default, dependencies declared with `implementation` are merged into `godot-bootstrap.jar`.
+Use `godotMain` for a dependency that must be loaded with user code and recreated when `main.jar`
+reloads:
+
+```kotlin
+dependencies {
+    godotMain("org.eclipse.serializer:serializer:4.0.1")
+}
+```
+
+Use `godotSingle` when a dependency must remain an intact JAR, such as a signed JAR. The plugin
+copies its resolved JARs to `res://jvm/external/` and adds them to `main.jar`'s class path:
+
+```kotlin
+dependencies {
+    godotSingle("org.bouncycastle:bcprov-jdk18on:1.79")
+}
+```
+
+Do not declare the same dependency in more than one of `implementation`, `godotMain`, or
+`godotSingle`.
 
 ## usercode
 

--- a/docs/src/doc/reference/gradle-plugin/packaging-and-tasks.md
+++ b/docs/src/doc/reference/gradle-plugin/packaging-and-tasks.md
@@ -33,6 +33,26 @@ When enabled, the plugin:
 
 Unlike `disableGdj`, `isLibrary` turns off the whole local runtime-registration pipeline rather than only the `.gdj` part of it.
 
+### `godotMain` and `godotSingle` dependencies
+
+Dependencies declared with `implementation` are merged into `godot-bootstrap.jar`. Two additional
+dependency configurations control different packaging requirements:
+
+```kotlin
+dependencies {
+    godotMain("org.eclipse.serializer:serializer:4.0.1")
+    godotSingle("org.bouncycastle:bcprov-jdk18on:1.79")
+}
+```
+
+- `godotMain` merges the dependency into `main.jar`. Use it when the library must load user-code
+  classes or be recreated with editor reloads.
+- `godotSingle` preserves the dependency as a separate JAR in `res://jvm/external/`. Use it for
+  signed JARs or libraries that cannot be merged safely.
+
+Both configurations are available while compiling and testing, but neither is merged into
+`godot-bootstrap.jar`.
+
 ## Build tasks
 
 The plugin adds a few higher-level tasks on top of the normal Gradle lifecycle.

--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -41,6 +41,8 @@ godot {
 
 dependencies {
     implementation("joda-time:joda-time:2.10.6") // external dependency to test dependency inclusion in mainCompilation
+    godotMain("org.apache.commons:commons-lang3:3.14.0")
+    godotSingle("commons-io:commons-io:2.15.1")
 
     implementation("com.godot.tests:third-party-library")
 

--- a/harness/tests/src/main/kotlin/godot/tests/dependencies/GodotDependencyConfigurations.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/dependencies/GodotDependencyConfigurations.kt
@@ -1,0 +1,12 @@
+package godot.tests.dependencies
+
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang3.StringUtils
+import java.nio.charset.StandardCharsets
+
+object GodotDependencyConfigurations {
+    fun mainJarDependency(): String = StringUtils.capitalize("godot")
+
+    fun singleJarDependency(): String =
+        IOUtils.toString(IOUtils.toInputStream("jvm", StandardCharsets.UTF_8), StandardCharsets.UTF_8)
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
@@ -4,8 +4,13 @@ import godot.gradle.GodotLanguage
 import godot.tools.common.BUILD_VERSION
 import godot.tools.common.KOTLIN_COROUTINE_VERSION
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+const val GODOT_MAIN_CONFIGURATION = "godotMain"
+const val GODOT_SINGLE_CONFIGURATION = "godotSingle"
 
 /**
  * Set's up all configurations and compilations needed for kotlin_jvm to work and defines proper task dependencies between them.
@@ -22,6 +27,11 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * - At runtime, the module uses `godot-bootstrap.jar` together with `main.jar`.
  */
 fun Project.setupConfigurationsAndCompilations() {
+    val godotMain = configurations.create(GODOT_MAIN_CONFIGURATION)
+    val godotSingle = configurations.create(GODOT_SINGLE_CONFIGURATION)
+
+    addGodotDependencyConfigurationsToSourceSets(godotMain, godotSingle)
+
     afterEvaluate {
         // Add all consumer-project main compilation dependencies in one place, after the user's
         // `godot { ... }` configuration has had a chance to override extension defaults.
@@ -77,5 +87,19 @@ fun Project.setupConfigurationsAndCompilations() {
             // add reflection explicitly so it's usable in exported projects as well. See: GH-571
             add(dependencies.create("org.jetbrains.kotlin:kotlin-reflect:$kotlinBuildVersion"))
         }
+    }
+}
+
+private fun Project.addGodotDependencyConfigurationsToSourceSets(
+    godotMain: Configuration,
+    godotSingle: Configuration,
+) {
+    val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+    val main = sourceSets.getByName("main")
+    configurations.getByName(main.compileClasspathConfigurationName).extendsFrom(godotMain, godotSingle)
+
+    sourceSets.findByName("test")?.let { test ->
+        configurations.getByName(test.compileClasspathConfigurationName).extendsFrom(godotMain, godotSingle)
+        configurations.getByName(test.runtimeClasspathConfigurationName).extendsFrom(godotMain, godotSingle)
     }
 }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packaging/copyJarsTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packaging/copyJarsTask.kt
@@ -1,9 +1,12 @@
 package godot.gradle.tasks
 
 import godot.gradle.tasks.registrar_generation.requireConfiguredGodotProjectDirectory
+import godot.gradle.projectExt.GODOT_SINGLE_CONFIGURATION
 import godot.tools.common.constants.Paths
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.CopySpec
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
@@ -45,6 +48,10 @@ fun Project.createCopyDesktopJarsTask(
     ) { libsDir ->
         from(File(libsDir, "godot-bootstrap.jar"))
         from(File(libsDir, "main.jar"))
+        from(
+            configurations.getByName(GODOT_SINGLE_CONFIGURATION).filter { it.extension == "jar" },
+            Action<CopySpec> { it.into("external") },
+        )
     }
 }
 

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packaging/packageMainJar.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packaging/packageMainJar.kt
@@ -1,6 +1,8 @@
 package godot.gradle.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import godot.gradle.projectExt.GODOT_MAIN_CONFIGURATION
+import godot.gradle.projectExt.GODOT_SINGLE_CONFIGURATION
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -21,6 +23,18 @@ fun Project.packageMainJarTask(
             archiveVersion.set("")
             archiveClassifier.set("")
             configurations.clear()
+            configurations.add(this@packageMainJarTask.configurations.getByName(GODOT_MAIN_CONFIGURATION))
+
+            val godotSingle = this@packageMainJarTask.configurations.getByName(GODOT_SINGLE_CONFIGURATION)
+            // Keep godotSingle dependencies as intact JARs while making them visible to the main URLClassLoader.
+            manifest.attributes[
+                "Class-Path"
+            ] = provider {
+                godotSingle.files
+                    .filter { it.extension == "jar" }
+                    .sortedBy { it.name }
+                    .joinToString(" ") { "external/${it.name}" }
+            }
 
             dependsOn(userClassesTask)
             dependsOn(generatedRegistrarJarTask)


### PR DESCRIPTION
Add godotMain and godotSingle dependency configurations
This adds two dependency placements for libraries that should not live in godot-bootstrap.jar.
- godotMain packages a dependency into main.jar. Use it for libraries that need to load or interact with user code, and should be recreated when user code reloads.
- godotSingle keeps a dependency as its own JAR in jvm/external/. Use it for signed JARs or libraries that cannot safely be merged into a fat JAR.

Example:

```kt
dependencies {
    godotMain("org.eclipse.serializer:serializer:4.0.1")
    godotSingle("org.bouncycastle:bcprov-jdk18on:1.79")
}
```

This gives projects control over dependency placement while preserving the default behavior for ordinary implementation dependencies.