### PR TITLE
Fix some registration and bridge bugs

### DIFF
--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -57,7 +57,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: jvm_api-generator
-          path: kt/api-generator/build/libs/api-generator.jar
+          path: |
+            kt/api-generator/build/libs/api-generator-*.jar
+            !kt/api-generator/build/libs/api-generator-*-sources.jar
+            !kt/api-generator/build/libs/api-generator-*-javadoc.jar
 
   build-ide-plugin:
     runs-on: ubuntu-latest

--- a/cpp/jvm/wrapper/bridge/bridges_utils.h
+++ b/cpp/jvm/wrapper/bridge/bridges_utils.h
@@ -1,7 +1,67 @@
 #ifndef GODOT_JVM_BRIDGES_UTILS_H
 #define GODOT_JVM_BRIDGES_UTILS_H
 
+#include "constraints.h"
 #include "jvm/jni/wrapper.h"
+#include "logging.h"
+
+// clang-format off
+//
+// godot-cpp exposes several builtin vararg methods (Callable::call, call_deferred, bind, rpc, rpc_id, ...) only as
+// variadic templates, so a runtime-sized argument array has to be unpacked into a compile-time arity by hand.
+// `m_call` is the callee expression (e.g. `callable.call_deferred` or `result = callable.call`), `m_args` a
+// Variant array holding `m_count` elements (0 <= m_count <= MAX_FUNCTION_ARG_COUNT) and `m_case_0` the statement
+// to run when there are no arguments, since some callees (rpc_id) require at least one.
+#define VARIADIC_ARGS_1(a) (a)[0]
+#define VARIADIC_ARGS_2(a) VARIADIC_ARGS_1(a), (a)[1]
+#define VARIADIC_ARGS_3(a) VARIADIC_ARGS_2(a), (a)[2]
+#define VARIADIC_ARGS_4(a) VARIADIC_ARGS_3(a), (a)[3]
+#define VARIADIC_ARGS_5(a) VARIADIC_ARGS_4(a), (a)[4]
+#define VARIADIC_ARGS_6(a) VARIADIC_ARGS_5(a), (a)[5]
+#define VARIADIC_ARGS_7(a) VARIADIC_ARGS_6(a), (a)[6]
+#define VARIADIC_ARGS_8(a) VARIADIC_ARGS_7(a), (a)[7]
+#define VARIADIC_ARGS_9(a) VARIADIC_ARGS_8(a), (a)[8]
+#define VARIADIC_ARGS_10(a) VARIADIC_ARGS_9(a), (a)[9]
+#define VARIADIC_ARGS_11(a) VARIADIC_ARGS_10(a), (a)[10]
+#define VARIADIC_ARGS_12(a) VARIADIC_ARGS_11(a), (a)[11]
+#define VARIADIC_ARGS_13(a) VARIADIC_ARGS_12(a), (a)[12]
+#define VARIADIC_ARGS_14(a) VARIADIC_ARGS_13(a), (a)[13]
+#define VARIADIC_ARGS_15(a) VARIADIC_ARGS_14(a), (a)[14]
+#define VARIADIC_ARGS_16(a) VARIADIC_ARGS_15(a), (a)[15]
+
+#define VARIADIC_CASE(n, m_call, m_args)        \
+    case n:                                     \
+        m_call(VARIADIC_ARGS_##n(m_args));      \
+        break;
+
+#define CALL_VARIADIC_OR(m_count, m_args, m_call, m_case_0)                 \
+    switch (m_count) {                                                      \
+        case 0:                                                             \
+            m_case_0;                                                       \
+            break;                                                          \
+        VARIADIC_CASE(1, m_call, m_args)                                    \
+        VARIADIC_CASE(2, m_call, m_args)                                    \
+        VARIADIC_CASE(3, m_call, m_args)                                    \
+        VARIADIC_CASE(4, m_call, m_args)                                    \
+        VARIADIC_CASE(5, m_call, m_args)                                    \
+        VARIADIC_CASE(6, m_call, m_args)                                    \
+        VARIADIC_CASE(7, m_call, m_args)                                    \
+        VARIADIC_CASE(8, m_call, m_args)                                    \
+        VARIADIC_CASE(9, m_call, m_args)                                    \
+        VARIADIC_CASE(10, m_call, m_args)                                   \
+        VARIADIC_CASE(11, m_call, m_args)                                   \
+        VARIADIC_CASE(12, m_call, m_args)                                   \
+        VARIADIC_CASE(13, m_call, m_args)                                   \
+        VARIADIC_CASE(14, m_call, m_args)                                   \
+        VARIADIC_CASE(15, m_call, m_args)                                   \
+        VARIADIC_CASE(16, m_call, m_args)                                   \
+        default:                                                            \
+            JVM_ERR_FAIL_MSG(#m_call ": too many arguments (%d)", m_count); \
+            break;                                                          \
+    }
+
+#define CALL_VARIADIC(m_count, m_args, m_call) CALL_VARIADIC_OR(m_count, m_args, m_call, m_call())
+// clang-format on
 
 namespace bridges {
 

--- a/cpp/jvm/wrapper/bridge/callable_bridge.cpp
+++ b/cpp/jvm/wrapper/bridge/callable_bridge.cpp
@@ -82,13 +82,9 @@ void CallableBridge::engine_call_bind(JNIEnv* p_raw_env, jobject p_instance, jlo
     godot::Variant args[MAX_FUNCTION_ARG_COUNT];
     uint32_t args_size {TransferContext::get_instance().read_args(env, args)};
 
-    // godot-cpp exposes no pointer-array bindp(); build an Array and go through bindv() instead.
-    godot::Array bind_args;
-    for (uint32_t i = 0; i < args_size; ++i) {
-        bind_args.push_back(args[i]);
-    }
-
-    godot::Variant result = from_uint_to_ptr<godot::Callable>(p_raw_ptr)->bindv(bind_args);
+    const godot::Callable& callable = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
+    godot::Variant result;
+    CALL_VARIADIC(args_size, args, result = callable.bind);
     TransferContext::get_instance().write_return_value(env, result);
 }
 
@@ -98,13 +94,9 @@ void CallableBridge::engine_call_call(JNIEnv* p_raw_env, jobject p_instance, jlo
     godot::Variant args[MAX_FUNCTION_ARG_COUNT];
     uint32_t args_size {TransferContext::get_instance().read_args(env, args)};
 
-    // godot-cpp exposes no pointer-array callp()/Callable::CallError; build an Array and go through callv() instead, which reports failures internally rather than via an out-param.
-    godot::Array call_args;
-    for (uint32_t i = 0; i < args_size; ++i) {
-        call_args.push_back(args[i]);
-    }
-
-    godot::Variant result = from_uint_to_ptr<godot::Callable>(p_raw_ptr)->callv(call_args);
+    const godot::Callable& callable = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
+    godot::Variant result;
+    CALL_VARIADIC(args_size, args, result = callable.call);
     TransferContext::get_instance().write_return_value(env, result);
 }
 
@@ -114,28 +106,8 @@ void CallableBridge::engine_call_call_deferred(JNIEnv* p_raw_env, jobject p_inst
     godot::Variant args[MAX_FUNCTION_ARG_COUNT];
     uint32_t args_size {TransferContext::get_instance().read_args(env, args)};
 
-    // godot-cpp's call_deferred() is a variadic template with no pointer-array/Array overload, so the runtime argument count has to be unpacked by hand.
     const godot::Callable& callable = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
-    switch (args_size) {
-        case 0: callable.call_deferred(); break;
-        case 1: callable.call_deferred(args[0]); break;
-        case 2: callable.call_deferred(args[0], args[1]); break;
-        case 3: callable.call_deferred(args[0], args[1], args[2]); break;
-        case 4: callable.call_deferred(args[0], args[1], args[2], args[3]); break;
-        case 5: callable.call_deferred(args[0], args[1], args[2], args[3], args[4]); break;
-        case 6: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5]); break;
-        case 7: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6]); break;
-        case 8: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7]); break;
-        case 9: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]); break;
-        case 10: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]); break;
-        case 11: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10]); break;
-        case 12: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11]); break;
-        case 13: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12]); break;
-        case 14: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13]); break;
-        case 15: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14]); break;
-        case 16: callable.call_deferred(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[11], args[12], args[13], args[14], args[15]); break;
-        default: JVM_ERR_FAIL_MSG("call_deferred: too many arguments"); break;
-    }
+    CALL_VARIADIC(args_size, args, callable.call_deferred);
 }
 
 void CallableBridge::engine_call_get_bound_arguments(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
@@ -214,14 +186,8 @@ void CallableBridge::engine_call_rpc(JNIEnv* p_raw_env, jobject p_instance, jlon
     godot::Variant args[MAX_FUNCTION_ARG_COUNT];
     uint32_t args_size {TransferContext::get_instance().read_args(env, args)};
 
-    const godot::Variant* args_ptr[MAX_FUNCTION_ARG_COUNT];
-    for (uint32_t i = 0; i < args_size; ++i) {
-        args_ptr[i] = &args[i];
-    }
-    godot::Variant instance = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
-    godot::Variant result;
-    GDExtensionCallError error;
-    instance.callp(SNAME("rpc"), args_ptr, static_cast<int>(args_size), result, error);
+    const godot::Callable& callable = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
+    CALL_VARIADIC(args_size, args, callable.rpc);
 }
 
 void CallableBridge::engine_call_rpc_id(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
@@ -230,15 +196,9 @@ void CallableBridge::engine_call_rpc_id(JNIEnv* p_raw_env, jobject p_instance, j
     godot::Variant args[MAX_FUNCTION_ARG_COUNT];
     uint32_t args_size {TransferContext::get_instance().read_args(env, args)};
 
-    const godot::Variant* args_ptr[MAX_FUNCTION_ARG_COUNT];
-    for (uint32_t i = 0; i < args_size; ++i) {
-        args_ptr[i] = &args[i];
-    }
-
-    godot::Variant instance = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
-    godot::Variant result;
-    GDExtensionCallError error;
-    instance.callp(SNAME("rpc_id"), args_ptr, static_cast<int>(args_size), result, error);
+    const godot::Callable& callable = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
+    // args[0] is the peer id (Variant converts to int64_t implicitly); the rest are the RPC arguments.
+    CALL_VARIADIC_OR(args_size, args, callable.rpc_id, JVM_ERR_FAIL_MSG("rpc_id: missing peer id"));
 }
 
 void CallableBridge::engine_call_unbind(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/cpp/jvm/wrapper/bridge/callable_bridge.cpp
+++ b/cpp/jvm/wrapper/bridge/callable_bridge.cpp
@@ -219,7 +219,9 @@ void CallableBridge::engine_call_rpc(JNIEnv* p_raw_env, jobject p_instance, jlon
         args_ptr[i] = &args[i];
     }
     godot::Variant instance = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
-    instance.call(SNAME("rpc"), args_ptr);
+    godot::Variant result;
+    GDExtensionCallError error;
+    instance.callp(SNAME("rpc"), args_ptr, static_cast<int>(args_size), result, error);
 }
 
 void CallableBridge::engine_call_rpc_id(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
@@ -234,7 +236,9 @@ void CallableBridge::engine_call_rpc_id(JNIEnv* p_raw_env, jobject p_instance, j
     }
 
     godot::Variant instance = *from_uint_to_ptr<godot::Callable>(p_raw_ptr);
-    instance.call(SNAME("rpc_id"), args_ptr);
+    godot::Variant result;
+    GDExtensionCallError error;
+    instance.callp(SNAME("rpc_id"), args_ptr, static_cast<int>(args_size), result, error);
 }
 
 void CallableBridge::engine_call_unbind(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/cpp/jvm/wrapper/bridge/packed_byte_array_bridge.cpp
+++ b/cpp/jvm/wrapper/bridge/packed_byte_array_bridge.cpp
@@ -192,6 +192,7 @@ void PackedByteArrayBridge::engine_call_encode_double(JNIEnv* p_raw_env, jobject
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_double"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_float(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -200,6 +201,7 @@ void PackedByteArrayBridge::engine_call_encode_float(JNIEnv* p_raw_env, jobject,
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_float"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_half(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -208,6 +210,7 @@ void PackedByteArrayBridge::engine_call_encode_half(JNIEnv* p_raw_env, jobject, 
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_half"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_s16(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -216,6 +219,7 @@ void PackedByteArrayBridge::engine_call_encode_s16(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_s16"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_s32(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -224,6 +228,7 @@ void PackedByteArrayBridge::engine_call_encode_s32(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_s32"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_s64(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -232,6 +237,7 @@ void PackedByteArrayBridge::engine_call_encode_s64(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_s64"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_s8(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -240,6 +246,7 @@ void PackedByteArrayBridge::engine_call_encode_s8(JNIEnv* p_raw_env, jobject, jl
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_s8"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_u16(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -248,6 +255,7 @@ void PackedByteArrayBridge::engine_call_encode_u16(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_u16"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_u32(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -256,6 +264,7 @@ void PackedByteArrayBridge::engine_call_encode_u32(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_u32"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_u64(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -264,6 +273,7 @@ void PackedByteArrayBridge::engine_call_encode_u64(JNIEnv* p_raw_env, jobject, j
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_u64"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_u8(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -272,6 +282,7 @@ void PackedByteArrayBridge::engine_call_encode_u8(JNIEnv* p_raw_env, jobject, jl
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
     instance.call(SNAME("encode_u8"), args[0], args[1]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_encode_var(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
@@ -279,7 +290,8 @@ void PackedByteArrayBridge::engine_call_encode_var(JNIEnv* p_raw_env, jobject, j
     godot::Variant args[3] = {};
     TransferContext::get_instance().read_args(env, args);
     godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_u8"), args[0], args[1], args[2]);
+    instance.call(SNAME("encode_var"), args[0], args[1], args[2]);
+    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_ascii(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {

--- a/cpp/jvm/wrapper/bridge/packed_byte_array_bridge.cpp
+++ b/cpp/jvm/wrapper/bridge/packed_byte_array_bridge.cpp
@@ -9,11 +9,7 @@ void PackedByteArrayBridge::engine_call_compress(JNIEnv* p_raw_env, jobject, jlo
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = pool.call(SNAME("compress"), args[0]);
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->compress(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -21,10 +17,7 @@ void PackedByteArrayBridge::engine_call_decode_double(JNIEnv* p_raw_env, jobject
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_double"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_double(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -32,10 +25,7 @@ void PackedByteArrayBridge::engine_call_decode_float(JNIEnv* p_raw_env, jobject,
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_float"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_float(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -43,10 +33,7 @@ void PackedByteArrayBridge::engine_call_decode_half(JNIEnv* p_raw_env, jobject, 
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_half"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_half(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -54,10 +41,7 @@ void PackedByteArrayBridge::engine_call_decode_s16(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_s16"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_s16(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -65,10 +49,7 @@ void PackedByteArrayBridge::engine_call_decode_s32(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_s32"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_s32(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -76,10 +57,7 @@ void PackedByteArrayBridge::engine_call_decode_s64(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_s64"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_s64(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -87,10 +65,7 @@ void PackedByteArrayBridge::engine_call_decode_s8(JNIEnv* p_raw_env, jobject, jl
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_s8"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_s8(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -98,10 +73,7 @@ void PackedByteArrayBridge::engine_call_decode_u16(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_u16"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_u16(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -109,10 +81,7 @@ void PackedByteArrayBridge::engine_call_decode_u32(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_u32"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_u32(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -120,10 +89,7 @@ void PackedByteArrayBridge::engine_call_decode_u64(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_u64"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_u64(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -131,10 +97,7 @@ void PackedByteArrayBridge::engine_call_decode_u8(JNIEnv* p_raw_env, jobject, jl
     jni::Env env {p_raw_env};
     godot::Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_u8"), args[0]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_u8(args[0].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -142,10 +105,7 @@ void PackedByteArrayBridge::engine_call_decode_var(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_var"), args[0], args[1]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_var(args[0].operator int64_t(), args[1].operator bool());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -153,10 +113,7 @@ void PackedByteArrayBridge::engine_call_decode_var_size(JNIEnv* p_raw_env, jobje
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = instance.call(SNAME("decode_var_size"), args[0], args[1]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decode_var_size(args[0].operator int64_t(), args[1].operator bool());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -164,11 +121,7 @@ void PackedByteArrayBridge::engine_call_decompress(JNIEnv* p_raw_env, jobject, j
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = pool.call(SNAME("decompress"), args[0], args[1]);
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decompress(args[0].operator int64_t(), args[1].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -176,13 +129,7 @@ void PackedByteArrayBridge::engine_call_decompress_dynamic(JNIEnv* p_raw_env, jo
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    auto t = args[0];
-
-    godot::Variant ret = pool.call(SNAME("decompress_dynamic"), args[0], args[1]);
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->decompress_dynamic(args[0].operator int64_t(), args[1].operator int64_t());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -190,148 +137,114 @@ void PackedByteArrayBridge::engine_call_encode_double(JNIEnv* p_raw_env, jobject
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_double"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_double(args[0].operator int64_t(), args[1].operator double());
 }
 
 void PackedByteArrayBridge::engine_call_encode_float(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_float"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_float(args[0].operator int64_t(), args[1].operator double());
 }
 
 void PackedByteArrayBridge::engine_call_encode_half(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_half"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_half(args[0].operator int64_t(), args[1].operator double());
 }
 
 void PackedByteArrayBridge::engine_call_encode_s16(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_s16"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_s16(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_s32(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_s32"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_s32(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_s64(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_s64"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_s64(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_s8(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_s8"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_s8(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_u16(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_u16"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_u16(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_u32(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_u32"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_u32(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_u64(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_u64"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_u64(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_u8(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_u8"), args[0], args[1]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_u8(args[0].operator int64_t(), args[1].operator int64_t());
 }
 
 void PackedByteArrayBridge::engine_call_encode_var(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
     godot::Variant args[3] = {};
     TransferContext::get_instance().read_args(env, args);
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    instance.call(SNAME("encode_var"), args[0], args[1], args[2]);
-    *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr) = instance;
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->encode_var(args[0].operator int64_t(), args[1], args[2].operator bool());
+    TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_ascii(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = pool.call(SNAME("get_string_from_ascii"));
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->get_string_from_ascii();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_utf16(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("get_string_from_utf16"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->get_string_from_utf16();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_utf32(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("get_string_from_utf32"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->get_string_from_utf32();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_wchar(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("get_string_from_wchar"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->get_string_from_wchar();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_get_string_from_utf8(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = pool.call(SNAME("get_string_from_utf8"));
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->get_string_from_utf8();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
@@ -339,47 +252,37 @@ void PackedByteArrayBridge::engine_call_has_encoded_var(JNIEnv* p_raw_env, jobje
     jni::Env env {p_raw_env};
     godot::Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("has_encoded_var"), args[0], args[1]);
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->has_encoded_var(args[0].operator int64_t(), args[1].operator bool());
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_hex_encode(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-
-    godot::Variant pool = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-
-    godot::Variant ret = pool.call(SNAME("hex_encode"));
-
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->hex_encode();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_to_float32_array(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("to_float32_array"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->to_float32_array();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_to_float64_array(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("to_float64_array"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->to_float64_array();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_to_int32_array(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("to_int32_array"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->to_int32_array();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 
 void PackedByteArrayBridge::engine_call_to_int64_array(JNIEnv* p_raw_env, jobject, jlong p_raw_ptr) {
     jni::Env env {p_raw_env};
-    godot::Variant instance = *from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr);
-    godot::Variant ret = instance.call(SNAME("to_int64_array"));
+    godot::Variant ret = from_uint_to_ptr<godot::PackedByteArray>(p_raw_ptr)->to_int64_array();
     TransferContext::get_instance().write_return_value(env, ret);
 }
 

--- a/harness/tests/src/main/kotlin/godot/tests/core/PackedArrayTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/core/PackedArrayTest.kt
@@ -159,7 +159,43 @@ class PackedArrayTest : Node() {
         val kotlinArr = arr.toVector4Array()
         return kotlinArr[index];
     }
+
+    @Register
+    fun encodeSignedIntegers(): PackedByteArray {
+        val bytes = PackedByteArray(ByteArray(15))
+        bytes.encodeS8(0, -7)
+        bytes.encodeS16(1, -1234)
+        bytes.encodeS32(3, -123456)
+        bytes.encodeS64(7, -1234567890123L)
+        return bytes
+    }
+
+    @Register
+    fun encodeUnsignedIntegers(): PackedByteArray {
+        val bytes = PackedByteArray(ByteArray(15))
+        bytes.encodeU8(0, 250)
+        bytes.encodeU16(1, 65000)
+        bytes.encodeU32(3, 2000000000)
+        bytes.encodeU64(7, 1234567890123L)
+        return bytes
+    }
+
+    @Register
+    fun encodeFloatingPointNumbers(): PackedByteArray {
+        val bytes = PackedByteArray(ByteArray(14))
+        bytes.encodeHalf(0, 1.5f)
+        bytes.encodeFloat(2, 3.25f)
+        bytes.encodeDouble(6, 6.125)
+        return bytes
+    }
+
+    @Register
+    fun encodeVariant(value: String): PackedByteArray {
+        val bytes = PackedByteArray(ByteArray(64))
+        bytes.encodeVar(0, value)
+        return bytes
+    }
+
+    @Register
+    fun decodeVariantSize(bytes: PackedByteArray): Int = bytes.decodeVarSize(0)
 }
-
-
-

--- a/harness/tests/src/main/kotlin/godot/tests/coroutine/CoroutineTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/coroutine/CoroutineTest.kt
@@ -11,10 +11,12 @@ import godot.api.Timer
 import godot.core.Vector2
 import godot.core.signal0
 import godot.core.signal1
+import godot.core.signal2
 import godot.core.signal4
 import godot.coroutines.GodotDispatchers
 import godot.coroutines.asFlow
 import godot.coroutines.await
+import godot.coroutines.awaitLoad
 import godot.coroutines.awaitLoadAs
 import godot.coroutines.awaitNextPhysicsProcess
 import godot.coroutines.awaitNextProcess
@@ -127,14 +129,38 @@ class CoroutineTest : Node() {
         }
     }
 
-    @Emit("is_test_successful")
-    val asyncLoadResourceFinished by signal1<Boolean>()
+    @Emit("is_loaded", "was_cached")
+    val asyncLoadUncachedResourceFinished by signal2<Boolean, Boolean>()
 
+    /** Loads a resource that no other test touches, so the load really runs on the worker pool. */
     @Register
-    fun asyncLoadResource() {
+    fun asyncLoadUncachedResource() {
+        val path = "res://test/coroutine/fixtures/uncached_load.tres"
+        val wasCached = ResourceLoader.hasCached(path)
         launch {
-            val resource = ResourceLoader.awaitLoadAs<PackedScene>("res://Spatial.tscn")
-            asyncLoadResourceFinished.emit(resource != null)
+            val resource = ResourceLoader.awaitLoad(path)
+            // The load may complete without suspending, so wait a frame to let the GDScript caller reach its await.
+            awaitNextProcess()
+            asyncLoadUncachedResourceFinished.emit(resource != null, wasCached)
+        }
+    }
+
+    @Emit("is_loaded", "was_cached")
+    val asyncLoadCachedResourceFinished by signal2<Boolean, Boolean>()
+
+    private var cachedResourceKeepAlive: PackedScene? = null
+
+    /** Loads a scene synchronously first and keeps it referenced, so the awaited load hits the cache. */
+    @Register
+    fun asyncLoadCachedResource() {
+        val path = "res://Spatial.tscn"
+        cachedResourceKeepAlive = ResourceLoader.load(path) as PackedScene?
+        val wasCached = ResourceLoader.hasCached(path)
+        launch {
+            val resource = ResourceLoader.awaitLoadAs<PackedScene>(path)
+            // A cached load returns immediately, so wait a frame to let the GDScript caller reach its await.
+            awaitNextProcess()
+            asyncLoadCachedResourceFinished.emit(resource != null, wasCached)
         }
     }
 

--- a/harness/tests/src/main/kotlin/godot/tests/multiplayer/LoopbackMultiplayerPeer.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/multiplayer/LoopbackMultiplayerPeer.kt
@@ -1,0 +1,144 @@
+package godot.tests.multiplayer
+
+import godot.annotation.Register
+import godot.annotation.Script
+import godot.annotation.Visible
+import godot.api.MultiplayerPeer
+import godot.api.MultiplayerPeerExtension
+import godot.core.Error
+import godot.core.PackedByteArray
+
+/**
+ * Delivers every packet it is asked to send back to itself as if a remote peer with id [REMOTE_PEER_ID]
+ * had sent it, so a single process can exercise the whole RPC path of the multiplayer API. SceneMultiplayer
+ * reads the peer, channel and mode before fetching a packet, so those describe the head of the queue.
+ */
+@Script
+class LoopbackMultiplayerPeer : MultiplayerPeerExtension() {
+    private class Packet(val bytes: ByteArray, val channel: Int, val mode: MultiplayerPeer.TransferMode)
+
+    private val outgoing = ArrayDeque<Packet>()
+    private val incoming = ArrayDeque<Packet>()
+    private var targetPeer = 0
+    private var requestedChannel = 0
+    private var requestedMode = MultiplayerPeer.TransferMode.RELIABLE
+    private var remotePeerAnnounced = false
+
+    @Visible
+    var pollCount = 0
+
+    @Visible
+    var sentPacketCount = 0
+
+    @Visible
+    var receivedPacketCount = 0
+
+    @Visible
+    var lastSentTransferModeId = -1
+
+    @Visible
+    var lastSentChannel = -1
+
+    @Visible
+    var lastTargetPeer = 0
+
+    @Register
+    override fun _getAvailablePacketCount(): Int = incoming.size
+
+    @Register
+    override fun _getMaxPacketSize(): Int = MAXIMUM_PACKET_SIZE
+
+    @Register
+    override fun _getPacketScript(): PackedByteArray {
+        val packet = incoming.removeFirst()
+        receivedPacketCount++
+        return PackedByteArray(packet.bytes)
+    }
+
+    @Register
+    override fun _putPacketScript(buffer: PackedByteArray): Error {
+        outgoing.addLast(Packet(buffer.toByteArray(), requestedChannel, requestedMode))
+        sentPacketCount++
+        lastSentTransferModeId = requestedMode.value.toInt()
+        lastSentChannel = requestedChannel
+        lastTargetPeer = targetPeer
+        return Error.OK
+    }
+
+    @Register
+    override fun _getPacketChannel(): Int = incoming.firstOrNull()?.channel ?: 0
+
+    @Register
+    override fun _getPacketMode(): MultiplayerPeer.TransferMode = incoming.firstOrNull()?.mode ?: MultiplayerPeer.TransferMode.RELIABLE
+
+    @Register
+    override fun _setTransferChannel(channel: Int) {
+        requestedChannel = channel
+    }
+
+    @Register
+    override fun _getTransferChannel(): Int = requestedChannel
+
+    @Register
+    override fun _setTransferMode(mode: MultiplayerPeer.TransferMode) {
+        requestedMode = mode
+    }
+
+    @Register
+    override fun _getTransferMode(): MultiplayerPeer.TransferMode = requestedMode
+
+    @Register
+    override fun _setTargetPeer(peer: Int) {
+        targetPeer = peer
+    }
+
+    @Register
+    override fun _getPacketPeer(): Int = REMOTE_PEER_ID
+
+    @Register
+    override fun _isServer(): Boolean = false
+
+    @Register
+    override fun _poll() {
+        pollCount++
+        if (!remotePeerAnnounced) {
+            remotePeerAnnounced = true
+            peerConnected.emit(REMOTE_PEER_ID.toLong())
+        }
+        while (outgoing.isNotEmpty()) {
+            incoming.addLast(outgoing.removeFirst())
+        }
+    }
+
+    @Register
+    override fun _close() {
+        outgoing.clear()
+        incoming.clear()
+    }
+
+    @Register
+    override fun _disconnectPeer(peer: Int, force: Boolean) {
+    }
+
+    @Register
+    override fun _getUniqueId(): Int = LOCAL_PEER_ID
+
+    @Register
+    override fun _setRefuseNewConnections(enable: Boolean) {
+    }
+
+    @Register
+    override fun _isRefusingNewConnections(): Boolean = false
+
+    @Register
+    override fun _isServerRelaySupported(): Boolean = false
+
+    @Register
+    override fun _getConnectionStatus(): MultiplayerPeer.ConnectionStatus = MultiplayerPeer.ConnectionStatus.CONNECTED
+
+    companion object {
+        const val LOCAL_PEER_ID = 2
+        const val REMOTE_PEER_ID = 1
+        const val MAXIMUM_PACKET_SIZE = 1 shl 16
+    }
+}

--- a/harness/tests/src/main/kotlin/godot/tests/multiplayer/RpcLoopbackTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/multiplayer/RpcLoopbackTest.kt
@@ -1,0 +1,45 @@
+package godot.tests.multiplayer
+
+import godot.annotation.Register
+import godot.annotation.Rpc
+import godot.annotation.RpcMode
+import godot.annotation.Script
+import godot.annotation.Visible
+import godot.api.Node
+import godot.core.methodCallable2
+
+@Script
+class RpcLoopbackTest : Node() {
+
+    @Visible
+    var receivedCount = 0
+
+    @Visible
+    var receivedLabel = ""
+
+    @Visible
+    var receivedFromPeer = 0
+
+    @Rpc(rpcMode = RpcMode.ANY)
+    @Register
+    fun receiveValues(count: Int, label: String) {
+        receivedCount = count
+        receivedLabel = label
+        receivedFromPeer = multiplayer?.getRemoteSenderId() ?: 0
+    }
+
+    @Register
+    fun triggerTypedRpc() {
+        rpc(::receiveValues, 3, "crate")
+    }
+
+    @Register
+    fun triggerMethodCallableRpc() {
+        methodCallable2(this, RpcLoopbackTest::receiveValues).rpc(5, "barrel")
+    }
+
+    @Register
+    fun triggerMethodCallableRpcId(peerId: Long) {
+        methodCallable2(this, RpcLoopbackTest::receiveValues).rpcId(peerId, 7, "lantern")
+    }
+}

--- a/harness/tests/src/main/kotlin/godot/tests/registration/RpcTransferModeTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/registration/RpcTransferModeTest.kt
@@ -1,0 +1,27 @@
+package godot.tests.registration
+
+import godot.annotation.Register
+import godot.annotation.Rpc
+import godot.annotation.RpcMode
+import godot.annotation.Script
+import godot.annotation.TransferMode
+import godot.api.Node
+
+@Script
+class RpcTransferModeTest : Node() {
+
+    @Rpc
+    @Register
+    fun defaultTransferMode() {
+    }
+
+    @Rpc(transferMode = TransferMode.UNRELIABLE)
+    @Register
+    fun unreliableTransferMode() {
+    }
+
+    @Rpc(rpcMode = RpcMode.ANY, transferMode = TransferMode.UNRELIABLE_ORDERED, transferChannel = 2)
+    @Register
+    fun unreliableOrderedTransferMode() {
+    }
+}

--- a/harness/tests/test/core/test_packed_arrays.gd
+++ b/harness/tests/test/core/test_packed_arrays.gd
@@ -168,3 +168,50 @@ func test_large_packed_string_array_conversion() -> void:
     assert_that(packed[3]).override_failure_message("Large PackedStringArray payloads should preserve the last string").is_equal("This is the fourth long packed string payload")
 
     script.free()
+
+
+func test_packed_byte_array_encode_signed_integers() -> void:
+    var script := PackedArrayTest.new()
+    var bytes: PackedByteArray = script.encode_signed_integers()
+
+    assert_that(bytes.decode_s8(0)).is_equal(-7)
+    assert_that(bytes.decode_s16(1)).is_equal(-1234)
+    assert_that(bytes.decode_s32(3)).is_equal(-123456)
+    assert_that(bytes.decode_s64(7)).is_equal(-1234567890123)
+
+    script.free()
+
+
+func test_packed_byte_array_encode_unsigned_integers() -> void:
+    var script := PackedArrayTest.new()
+    var bytes: PackedByteArray = script.encode_unsigned_integers()
+
+    assert_that(bytes.decode_u8(0)).is_equal(250)
+    assert_that(bytes.decode_u16(1)).is_equal(65000)
+    assert_that(bytes.decode_u32(3)).is_equal(2000000000)
+    assert_that(bytes.decode_u64(7)).is_equal(1234567890123)
+
+    script.free()
+
+
+func test_packed_byte_array_encode_floating_point_numbers() -> void:
+    var script := PackedArrayTest.new()
+    var bytes: PackedByteArray = script.encode_floating_point_numbers()
+
+    assert_that(bytes.decode_half(0)).is_equal(1.5)
+    assert_that(bytes.decode_float(2)).is_equal(3.25)
+    assert_that(bytes.decode_double(6)).is_equal(6.125)
+
+    script.free()
+
+
+func test_packed_byte_array_encode_and_size_variant() -> void:
+    var script := PackedArrayTest.new()
+    var expected := var_to_bytes("wrench")
+    var bytes: PackedByteArray = script.encode_variant("wrench")
+
+    assert_that(bytes.decode_var(0)).is_equal("wrench")
+    assert_that(bytes.slice(0, expected.size())).override_failure_message("encode_var must write the same bytes as var_to_bytes").is_equal(expected)
+    assert_that(script.decode_variant_size(expected)).override_failure_message("decode_var_size must return the encoded size, not the value").is_equal(expected.size())
+
+    script.free()

--- a/harness/tests/test/coroutine/fixtures/uncached_load.tres
+++ b/harness/tests/test/coroutine/fixtures/uncached_load.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Resource" format=3]
+
+[resource]
+resource_name = "coroutine_uncached_load"

--- a/harness/tests/test/coroutine/test_coroutines.gd
+++ b/harness/tests/test/coroutine/test_coroutines.gd
@@ -58,9 +58,15 @@ func test_coroutine_await():
     var run_on_main_thread_from_background_thread_success = await test_script.run_on_main_thread_from_background_thread_finished
     assert_bool(run_on_main_thread_from_background_thread_success).override_failure_message("Code should be executed on the correct threads").is_true()
 
-    test_script.async_load_resource()
-    var async_load_resource_success = await test_script.async_load_resource_finished
-    assert_bool(async_load_resource_success).override_failure_message("Resource should be loaded").is_true()
+    test_script.async_load_uncached_resource()
+    var uncached_load = await test_script.async_load_uncached_resource_finished
+    assert_bool(uncached_load[1]).override_failure_message("The uncached fixture must not be in the cache before the load").is_false()
+    assert_bool(uncached_load[0]).override_failure_message("Uncached resource should be loaded").is_true()
+
+    test_script.async_load_cached_resource()
+    var cached_load = await test_script.async_load_cached_resource_finished
+    assert_bool(cached_load[1]).override_failure_message("Spatial.tscn should already be cached before the load").is_true()
+    assert_bool(cached_load[0]).override_failure_message("Cached resource should be loaded").is_true()
     
     test_script.cancel_coroutine()
     await get_tree().create_timer(4).timeout

--- a/harness/tests/test/multiplayer/test_rpc_loopback.gd
+++ b/harness/tests/test/multiplayer/test_rpc_loopback.gd
@@ -1,0 +1,52 @@
+extends GdUnitTestSuite
+
+
+func _install_loopback(node: Node) -> LoopbackMultiplayerPeer:
+    get_tree().root.add_child(node)
+    var peer := LoopbackMultiplayerPeer.new()
+    get_tree().get_multiplayer().multiplayer_peer = peer
+    get_tree().get_multiplayer().poll()
+    assert_that(get_tree().get_multiplayer().get_peers()).override_failure_message("polling the loopback peer once must announce the remote peer").contains([1])
+    return peer
+
+
+func _remove_loopback(node: Node) -> void:
+    get_tree().get_multiplayer().multiplayer_peer = null
+    get_tree().root.remove_child(node)
+    node.free()
+
+
+func test_typed_rpc_is_sent_reliably_and_delivered_through_the_extension_peer() -> void:
+    var node := RpcLoopbackTest.new()
+    var peer := _install_loopback(node)
+
+    node.trigger_typed_rpc()
+    assert_that(peer.sent_packet_count).override_failure_message("the rpc must reach _put_packet_script").is_greater(0)
+    assert_that(peer.last_sent_transfer_mode_id).override_failure_message("@Rpc defaults to the reliable transfer mode").is_equal(MultiplayerPeer.TRANSFER_MODE_RELIABLE)
+    assert_that(peer.last_sent_channel).is_equal(0)
+    assert_that(node.received_count).override_failure_message("the rpc must not run locally without sync").is_equal(0)
+
+    get_tree().get_multiplayer().poll()
+    assert_that(peer.received_packet_count).override_failure_message("polling must hand the looped packets to _get_packet_script").is_greater(0)
+    assert_that(node.received_count).is_equal(3)
+    assert_that(node.received_label).is_equal("crate")
+    assert_that(node.received_from_peer).is_equal(1)
+
+    _remove_loopback(node)
+
+
+func test_method_callable_rpc_spreads_its_arguments() -> void:
+    var node := RpcLoopbackTest.new()
+    _install_loopback(node)
+
+    node.trigger_method_callable_rpc()
+    get_tree().get_multiplayer().poll()
+    assert_that(node.received_count).override_failure_message("MethodCallable.rpc must forward each argument on its own").is_equal(5)
+    assert_that(node.received_label).is_equal("barrel")
+
+    node.trigger_method_callable_rpc_id(1)
+    get_tree().get_multiplayer().poll()
+    assert_that(node.received_count).override_failure_message("MethodCallable.rpcId must forward each argument on its own").is_equal(7)
+    assert_that(node.received_label).is_equal("lantern")
+
+    _remove_loopback(node)

--- a/harness/tests/test/multiplayer/test_rpc_loopback.gd.uid
+++ b/harness/tests/test/multiplayer/test_rpc_loopback.gd.uid
@@ -1,0 +1,1 @@
+uid://ca0ks0efty8fj

--- a/harness/tests/test/registration/test_rpc_transfer_mode.gd
+++ b/harness/tests/test/registration/test_rpc_transfer_mode.gd
@@ -1,0 +1,30 @@
+extends GdUnitTestSuite
+
+
+func _config_for(rpc_config: Dictionary, method_name: String) -> Dictionary:
+    for key in rpc_config.keys():
+        if str(key) == method_name:
+            return rpc_config[key]
+    fail("No rpc configuration found for %s in %s" % [method_name, rpc_config])
+    return {}
+
+
+func test_rpc_annotation_values_map_to_engine_enum_values() -> void:
+    var script := RpcTransferModeTest.new()
+    var rpc_config: Dictionary = script.get_script().get_rpc_config()
+
+    var default_config := _config_for(rpc_config, "default_transfer_mode")
+    assert_that(default_config["transfer_mode"]).override_failure_message("@Rpc defaults to the reliable transfer mode").is_equal(MultiplayerPeer.TRANSFER_MODE_RELIABLE)
+    assert_that(default_config["rpc_mode"]).override_failure_message("@Rpc defaults to the authority rpc mode").is_equal(MultiplayerAPI.RPC_MODE_AUTHORITY)
+    assert_that(default_config["call_local"]).is_equal(false)
+    assert_that(default_config["channel"]).is_equal(0)
+
+    var unreliable_config := _config_for(rpc_config, "unreliable_transfer_mode")
+    assert_that(unreliable_config["transfer_mode"]).override_failure_message("TransferMode.UNRELIABLE must map to the engine's unreliable mode").is_equal(MultiplayerPeer.TRANSFER_MODE_UNRELIABLE)
+
+    var ordered_config := _config_for(rpc_config, "unreliable_ordered_transfer_mode")
+    assert_that(ordered_config["transfer_mode"]).override_failure_message("TransferMode.UNRELIABLE_ORDERED must map to the engine's unreliable ordered mode").is_equal(MultiplayerPeer.TRANSFER_MODE_UNRELIABLE_ORDERED)
+    assert_that(ordered_config["rpc_mode"]).override_failure_message("RpcMode.ANY must map to the engine's any peer mode").is_equal(MultiplayerAPI.RPC_MODE_ANY_PEER)
+    assert_that(ordered_config["channel"]).is_equal(2)
+
+    script.free()

--- a/harness/tests/test/registration/test_rpc_transfer_mode.gd.uid
+++ b/harness/tests/test/registration/test_rpc_transfer_mode.gd.uid
@@ -1,0 +1,1 @@
+uid://bywq63u3rrfdk

--- a/kt/godot-library/godot-bootstrap-library/src/main/kotlin/godot/annotation/Rpc.kt
+++ b/kt/godot-library/godot-bootstrap-library/src/main/kotlin/godot/annotation/Rpc.kt
@@ -19,7 +19,6 @@ annotation class Rpc(
     val transferChannel: Int = 0
 )
 
-val test = RpcMode.DISABLED.ordinal
 // the reason for not using the generated enums for RPCMode or TransferMode directly is the naming is inconsistent with the one, users are used to from GDScript and thus the documentation
 /**
  * Defines the targets for rpc calls

--- a/kt/godot-library/godot-bootstrap-library/src/main/kotlin/godot/registration/KtClassBuilder.kt
+++ b/kt/godot-library/godot-bootstrap-library/src/main/kotlin/godot/registration/KtClassBuilder.kt
@@ -1,5 +1,7 @@
 package godot.registration
 
+import godot.annotation.RpcMode
+import godot.annotation.TransferMode
 import godot.common.extensions.convertToSnakeCase
 import godot.common.interop.VariantConverter
 import godot.core.*
@@ -42,11 +44,24 @@ class KtClassBuilder<T : KtObject>(
     ): KtPropertyInfo = KtPropertyInfo(type, className)
 
     fun rpc(
-        rpcMode: Enum<*>,
+        rpcMode: RpcMode,
         callLocal: Boolean,
-        transferMode: Enum<*>,
+        transferMode: TransferMode,
         channel: Int,
-    ): KtRpcConfig = KtRpcConfig(rpcMode.ordinal, callLocal, transferMode.ordinal, channel)
+    ): KtRpcConfig = KtRpcConfig(rpcMode.toEngineValue(), callLocal, transferMode.toEngineValue(), channel)
+
+    // The annotation enums are ordered like the GDScript documentation, not like the engine enums they map to.
+    private fun RpcMode.toEngineValue(): Int = when (this) {
+        RpcMode.DISABLED -> 0
+        RpcMode.ANY -> 1
+        RpcMode.AUTHORITY -> 2
+    }
+
+    private fun TransferMode.toEngineValue(): Int = when (this) {
+        TransferMode.UNRELIABLE -> 0
+        TransferMode.UNRELIABLE_ORDERED -> 1
+        TransferMode.RELIABLE -> 2
+    }
 
     fun <P : Any?> property(
         kProperty: KProperty1<T, P>,

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/packed/PackedByteArray.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/packed/PackedByteArray.kt
@@ -222,7 +222,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun decodeVarSize(byteOffset: Int, allowObjects: Boolean = false): Int {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantParser.BOOL to allowObjects)
-        Bridge.engine_call_decode_var(ptr)
+        Bridge.engine_call_decode_var_size(ptr)
         return TransferContext.readReturnValue(VariantCaster.INT) as Int
     }
 
@@ -278,7 +278,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeFloat(byteOffset: Int, value: Float) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.FLOAT to value)
-        Bridge.engine_call_encode_double(ptr)
+        Bridge.engine_call_encode_float(ptr)
     }
 
     /**
@@ -287,7 +287,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeHalf(byteOffset: Int, value: Float) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.FLOAT to value)
-        Bridge.engine_call_encode_double(ptr)
+        Bridge.engine_call_encode_half(ptr)
     }
 
     /**
@@ -296,7 +296,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeS16(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_s16(ptr)
+        Bridge.engine_call_encode_s16(ptr)
     }
 
     /**
@@ -305,7 +305,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeS32(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_s32(ptr)
+        Bridge.engine_call_encode_s32(ptr)
     }
 
     /**
@@ -314,7 +314,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeS64(byteOffset: Int, value: Long) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantParser.LONG to value)
-        Bridge.engine_call_decode_s64(ptr)
+        Bridge.engine_call_encode_s64(ptr)
     }
 
     /**
@@ -323,7 +323,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeS8(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_s8(ptr)
+        Bridge.engine_call_encode_s8(ptr)
     }
 
     /**
@@ -332,7 +332,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeU16(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_u16(ptr)
+        Bridge.engine_call_encode_u16(ptr)
     }
 
     /**
@@ -341,7 +341,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeU32(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_u32(ptr)
+        Bridge.engine_call_encode_u32(ptr)
     }
 
     /**
@@ -350,7 +350,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeU64(byteOffset: Int, value: Long) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantParser.LONG to value)
-        Bridge.engine_call_decode_u64(ptr)
+        Bridge.engine_call_encode_u64(ptr)
     }
 
     /**
@@ -359,7 +359,7 @@ class PackedByteArray : PackedArray<PackedByteArray, Byte> {
      */
     fun encodeU8(byteOffset: Int, value: Int) {
         TransferContext.writeArguments(VariantCaster.INT to byteOffset, VariantCaster.INT to value)
-        Bridge.engine_call_decode_u8(ptr)
+        Bridge.engine_call_encode_u8(ptr)
     }
 
     /**

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
@@ -23,8 +23,8 @@ open class MethodCallable internal constructor(
     override fun isNull() = false
     override fun isStandard() = true
     override fun isValid() = MemoryManager.isInstanceValid(target) && target.hasMethod(methodName)
-    override fun rpc(vararg args: Any?) = toNativeCallable().rpc(args)
-    override fun rpcId(peerId: Long, vararg args: Any?) = toNativeCallable().rpcId(peerId, args)
+    override fun rpc(vararg args: Any?) = toNativeCallable().rpc(*args)
+    override fun rpcId(peerId: Long, vararg args: Any?) = toNativeCallable().rpcId(peerId, *args)
     override fun unbind(argCount: Int) = toNativeCallable().unbind(argCount)
     override fun bindUnsafe(vararg args: Any?) = MethodCallable(target, methodName, arrayOf<Any?>(*args, *boundArgs))
     override fun callUnsafe(vararg args: Any?) = target.call(methodName, *args, *boundArgs)

--- a/kt/godot-library/godot-coroutine-library/src/main/kotlin/godot/coroutines/awaitResourceLoad.kt
+++ b/kt/godot-library/godot-coroutine-library/src/main/kotlin/godot/coroutines/awaitResourceLoad.kt
@@ -19,9 +19,13 @@ suspend inline fun ResourceLoader.awaitLoad(
     typeHint: String = "",
     cacheMode: CacheMode = CacheMode.REUSE,
 ): Resource? {
+    // Early return in case the resource is already loaded.
+    if (hasCached(path)) {
+        return load(path, typeHint, cacheMode)
+    }
+
     // Switch to the worker thread pool so the load doesn't block the caller's thread
-    // (especially important when the caller is on the main thread). This also makes
-    // cached and uncached loads complete asynchronously.
+    // (especially important when the caller is on the main thread).
     return withContext(GodotDispatchers.ThreadPool) {
         load(path, typeHint, cacheMode)
     }

--- a/kt/godot-registration/godot-registrar-generator/src/main/kotlin/godot/registrar/generator/generator/FunctionRegistrationGenerator.kt
+++ b/kt/godot-registration/godot-registrar-generator/src/main/kotlin/godot/registrar/generator/generator/FunctionRegistrationGenerator.kt
@@ -6,7 +6,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.MemberName.Companion.member
 import godot.annotation.RpcMode
 import godot.annotation.Sync
-import godot.api.MultiplayerPeer
+import godot.annotation.TransferMode
 import godot.registrar.generator.GeneratorContext
 import godot.registrar.generator.ext.asEnumName
 import godot.registrar.generator.ext.effectiveFunctions
@@ -16,6 +16,7 @@ import godot.registrar.generator.ext.toKtVariantMemberName
 import godot.registration.model.RegisteredFunction
 import godot.registration.model.ext.isEnum
 import godot.registration.model.types.ScriptClass
+import godot.registration.model.types.Type
 
 fun FunSpec.Builder.addNotificationRegistrations(
     registeredClass: ScriptClass,
@@ -68,8 +69,10 @@ private fun getFunctionTemplateString(registeredFunction: RegisteredFunction) = 
 
     append("function(%L, rpc(%M, %L, %M, %L), returns($variantType, %S)")
 
-    if (registeredFunction.parameters.isNotEmpty()) {
-        registeredFunction.parameters.forEach { _ ->
+    registeredFunction.parameters.forEach { valueParameter ->
+        if (valueParameter.type.isEnum()) {
+            append(", argument(%M(%T.entries.toTypedArray()), %S, %S)")
+        } else {
             append(", argument(%M, %S, %S)")
         }
     }
@@ -84,10 +87,7 @@ private fun getTemplateArgs(
 ): List<Any> {
     val returnType = registeredFunction.returnType.toGodotClassName(context)
     val typeClassName = if (registeredFunction.returnType.isEnum()) {
-        ClassName(
-            registeredFunction.returnType.fqName.substringBeforeLast("."),
-            registeredFunction.returnType.fqName.substringAfterLast("."),
-        )
+        registeredFunction.returnType.toEnumClassName()
     } else {
         null
     }
@@ -110,6 +110,9 @@ private fun getTemplateArgs(
 
         registeredFunction.parameters.forEach { valueParameter ->
             add(valueParameter.type.toKtVariantMemberName())
+            if (valueParameter.type.isEnum()) {
+                add(valueParameter.type.toEnumClassName())
+            }
             add(valueParameter.type.toGodotClassName(context))
             add(valueParameter.name)
         }
@@ -124,7 +127,7 @@ private fun getRpcModeEnum(registeredFunction: RegisteredFunction) =
     registeredFunction.rpcConfig?.rpcMode?.asEnumName() ?: RpcMode.DISABLED.asEnumName()
 
 private fun getRpcTransferModeEnum(registeredFunction: RegisteredFunction) =
-    registeredFunction.rpcConfig?.transferMode?.asEnumName() ?: MultiplayerPeer.TransferMode.RELIABLE.asEnumName()
+    registeredFunction.rpcConfig?.transferMode?.asEnumName() ?: TransferMode.RELIABLE.asEnumName()
 
 private fun getRpcCallLocal(registeredFunction: RegisteredFunction): Boolean =
     when (registeredFunction.rpcConfig?.sync) {
@@ -135,3 +138,8 @@ private fun getRpcCallLocal(registeredFunction: RegisteredFunction): Boolean =
 
 private fun getRpcChannel(registeredFunction: RegisteredFunction): Int =
     registeredFunction.rpcConfig?.transferChannel ?: 0
+
+private fun Type.toEnumClassName() = ClassName(
+    fqName.substringBeforeLast("."),
+    fqName.substringAfterLast("."),
+)


### PR DESCRIPTION
Fixes some enum ordering bugs and internal binding bugs i encountered while migrating one of my libs.

Regarding the cpp changes: please review carefully! As you know I'm not a cpp wizard and AI helped me a bit there but i know godot-cpp and cpp in general to little to verify that is not senseless. I can only verify that it works now ^^

Relevant cpp changes you should look at carefully:
- callable_bridge.cpp: Variant::call takes a fixed list of arguments, so the pointer to the argument array was sent as one single, argument instead of the real arguments; callp sends the array together with the number of arguments known at runtime.
- packed_byte_array_bridge.cpp: the encode functions wrote into a private copy of the array, so the array on the JVM side stayed unchanged; the modified copy is now stored back into the caller's array.